### PR TITLE
Add support for EInputType.Time

### DIFF
--- a/Jui/Views/InputView.cs
+++ b/Jui/Views/InputView.cs
@@ -176,6 +176,9 @@ namespace HomeSeer.Jui.Views {
 	            case EInputType.Decimal:
 		            typeString = "number\" step=\"0.001\" ";
 		            break;
+	            case EInputType.Time:
+		            typeString = "time\" ";
+		            break;
 	            default:
 		            throw new ArgumentOutOfRangeException();
             }


### PR DESCRIPTION
Modified the switch statement to allow EInputType.Time to be accepted in the InputView (it works everywhere else)