### PR TITLE
Release v1.4.3

### DIFF
--- a/Events/AbstractActionType.cs
+++ b/Events/AbstractActionType.cs
@@ -64,7 +64,7 @@ namespace HomeSeer.PluginSdk.Events {
         /// -1 if it is not set
         /// </remarks>
         protected int SelectedSubActionIndex { get; private set; } = -1;
-        
+
         /// <summary>
         /// Initialize a new <see cref="AbstractActionType"/> with the specified ID, Event Ref, and Data byte array.
         ///  The byte array will be automatically parsed for a <see cref="Page"/>, and a new one will be created if
@@ -78,8 +78,10 @@ namespace HomeSeer.PluginSdk.Events {
         /// </para>
         /// </summary>
         /// <param name="id">The unique ID of this action in HomeSeer</param>
+        /// <param name="subTypeNumber">The action subtype number</param>
         /// <param name="eventRef">The event reference ID that this action is associated with in HomeSeer</param>
         /// <param name="dataIn">A byte array containing the definition for a <see cref="Page"/></param>
+        /// <param name="listener">The listener that facilitates the communication with <see cref="AbstractPlugin"/></param>
         protected AbstractActionType(int id, int subTypeNumber, int eventRef, byte[] dataIn, ActionTypeCollection.IActionTypeListener listener) {
             _id                    = id;
             SelectedSubActionIndex = subTypeNumber;
@@ -104,6 +106,8 @@ namespace HomeSeer.PluginSdk.Events {
         /// <param name="id">The unique ID of this action in HomeSeer</param>
         /// <param name="eventRef">The event reference ID that this action is associated with in HomeSeer</param>
         /// <param name="dataIn">A byte array containing the definition for a <see cref="Page"/></param>
+        /// <param name="listener">The listener that facilitates the communication with <see cref="AbstractPlugin"/></param>
+        /// <param name="logDebug">If true debug messages will be written to the console</param>
         protected AbstractActionType(int id, int eventRef, byte[] dataIn, ActionTypeCollection.IActionTypeListener listener, bool logDebug = false) {
             _id           = id;
             _eventRef     = eventRef;
@@ -112,7 +116,7 @@ namespace HomeSeer.PluginSdk.Events {
             LogDebug = logDebug;
             InflateActionFromData();
         }
-        
+
         /// <summary>
         /// Initialize a new <see cref="AbstractActionType"/> with the specified ID, Event Ref, and Data byte array.
         ///  The byte array will be automatically parsed for a <see cref="Page"/>, and a new one will be created if
@@ -128,6 +132,7 @@ namespace HomeSeer.PluginSdk.Events {
         /// <param name="id">The unique ID of this action in HomeSeer</param>
         /// <param name="eventRef">The event reference ID that this action is associated with in HomeSeer</param>
         /// <param name="dataIn">A byte array containing the definition for a <see cref="Page"/></param>
+        /// <param name="listener">The listener that facilitates the communication with <see cref="AbstractPlugin"/></param>
         protected AbstractActionType(int id, int eventRef, byte[] dataIn, ActionTypeCollection.IActionTypeListener listener) {
             _id            = id;
             _eventRef      = eventRef;
@@ -294,9 +299,9 @@ namespace HomeSeer.PluginSdk.Events {
                     continue;
                 }
 
-                var viewType = ConfigPage.GetViewById(viewId).Type;
+                var originalView = ConfigPage.GetViewById(viewId);
                 try {
-                    pageChanges.AddViewDelta(viewId, (int) viewType, changes[viewId]);
+                    pageChanges.AddViewDelta(originalView, changes[viewId]);
                 }
                 catch (Exception exception) {
                     //Failed to add view change
@@ -314,7 +319,7 @@ namespace HomeSeer.PluginSdk.Events {
             return true;
         }
 
-        private byte[] ProcessData(byte[] inData) {
+        internal virtual byte[] ProcessData(byte[] inData) {
             //Is data null/empty?
             if (inData == null || inData.Length == 0) {
                 return new byte[0];
@@ -382,11 +387,12 @@ namespace HomeSeer.PluginSdk.Events {
             }
         }
 
-        private byte[] GetData() {
+        internal virtual byte[] GetData() {
             var pageJson = ConfigPage.ToJsonString();
             return Encoding.UTF8.GetBytes(pageJson);
         }
 
+        /// <inheritdoc />
         public override bool Equals(object obj) {
             if (ReferenceEquals(null, obj)) return false;
             if (ReferenceEquals(this, obj)) return true;
@@ -411,6 +417,7 @@ namespace HomeSeer.PluginSdk.Events {
             return true;
         }
 
+        /// <inheritdoc />
         public override int GetHashCode() {
             return 271828 * _id.GetHashCode() * _eventRef.GetHashCode();
         }

--- a/Events/AbstractActionType2.cs
+++ b/Events/AbstractActionType2.cs
@@ -1,0 +1,149 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using HomeSeer.Jui.Types;
+using HomeSeer.Jui.Views;
+using HomeSeer.PluginSdk.Devices;
+using Newtonsoft.Json;
+
+namespace HomeSeer.PluginSdk.Events {
+
+    /// <summary>
+    /// The base implementation of a plugin action type available for users to select in HomeSeer
+    /// <para>
+    /// The difference between <see cref="AbstractActionType2"/> and <see cref="AbstractActionType"/>, is that with
+    /// <see cref="AbstractActionType2"/> only a collection of view Id/Value pairs is stored in database whereas with 
+    /// <see cref="AbstractActionType"/> the whole <see cref="AbstractActionType.ConfigPage"/> is stored. This allows 
+    /// the plugin to build the views in <see cref="OnInstantiateAction"/> every time an action is instantiated.
+    /// </para>
+    /// <para>
+    /// Inherit from this class to define your own action types and store them in your plugin's <see cref="ActionTypeCollection"/>
+    /// </para>
+    /// </summary>
+    public abstract class AbstractActionType2: AbstractActionType {
+
+        /// <summary>
+        /// Initialize a new <see cref="AbstractActionType2"/> with the specified ID, SubType number, Event Ref, Data byte array and listener.
+        ///  The byte array will be automatically parsed to a collection of view Id/Value pairs, and <see cref="OnInstantiateAction"/> will be called
+        /// <para>
+        /// This is called through reflection by the <see cref="ActionTypeCollection"/> class if a class that
+        ///  derives from this type is added to its list.
+        /// </para>
+        /// <para>
+        /// You MUST implement one of these constructors in any class that derives from <see cref="AbstractActionType2"/>
+        /// </para>
+        /// </summary>
+        /// <param name="id">The unique ID of this action in HomeSeer</param>
+        /// <param name="subTypeNumber">The action subtype number</param>
+        /// <param name="eventRef">The event reference ID that this action is associated with in HomeSeer</param>
+        /// <param name="dataIn">A byte array containing a collection of view Id/Value pairs</param>
+        /// <param name="listener">The listener that facilitates the communication with <see cref="AbstractPlugin"/></param>
+        protected AbstractActionType2(int id, int subTypeNumber, int eventRef, byte[] dataIn, ActionTypeCollection.IActionTypeListener listener) 
+            :base(id, subTypeNumber, eventRef, dataIn, listener) {
+        }
+
+        /// <summary>
+        /// Initialize a new <see cref="AbstractActionType2"/> with the specified ID, Event Ref, Data byte array, listener, and logDebug flag.
+        ///  The byte array will be automatically parsed to a collection of view Id/Value pairs, and <see cref="OnInstantiateAction"/> will be called
+        /// <para>
+        /// This is called through reflection by the <see cref="ActionTypeCollection"/> class if a class that
+        ///  derives from this type is added to its list.
+        /// </para>
+        /// <para>
+        /// You MUST implement one of these constructors in any class that derives from <see cref="AbstractActionType2"/>
+        /// </para>
+        /// </summary>
+        /// <param name="id">The unique ID of this action in HomeSeer</param>
+        /// <param name="eventRef">The event reference ID that this action is associated with in HomeSeer</param>
+        /// <param name="dataIn">A byte array containing a collection of view Id/Value pairs</param>
+        /// <param name="listener">The listener that facilitates the communication with <see cref="AbstractPlugin"/></param>
+        /// <param name="logDebug">If true debug messages will be written to the console</param>
+        protected AbstractActionType2(int id, int eventRef, byte[] dataIn, ActionTypeCollection.IActionTypeListener listener, bool logDebug = false) :
+            base(id, eventRef, dataIn, listener, logDebug) {
+        }
+
+        /// <summary>
+        /// Initialize a new <see cref="AbstractActionType2"/> with the specified ID, Event Ref, and Data byte array.
+        ///  The byte array will be automatically parsed to a collection of view Id/Value pairs, and <see cref="OnInstantiateAction"/> will be called.
+        /// <para>
+        /// This is called through reflection by the <see cref="ActionTypeCollection"/> class if a class that
+        ///  derives from this type is added to its list.
+        /// </para>
+        /// <para>
+        /// You MUST implement one of these constructors in any class that derives from <see cref="AbstractActionType2"/>
+        /// </para>
+        /// </summary>
+        /// <param name="id">The unique ID of this action in HomeSeer</param>
+        /// <param name="eventRef">The event reference ID that this action is associated with in HomeSeer</param>
+        /// <param name="dataIn">A byte array containing a collection of view Id/Value pairs</param>
+        /// <param name="listener">The listener that facilitates the communication with <see cref="AbstractPlugin"/></param>
+        protected AbstractActionType2(int id, int eventRef, byte[] dataIn, ActionTypeCollection.IActionTypeListener listener) :
+            base(id, eventRef, dataIn, listener) {
+        }
+
+        /// <summary>
+        /// Initialize a new, unconfigured <see cref="AbstractActionType2"/>
+        /// <para>
+        /// This is called through reflection by the <see cref="ActionTypeCollection"/> class if a class that
+        ///  derives from this type is added to its list.
+        /// </para>
+        /// </summary>
+        protected AbstractActionType2() : base() {}
+
+        /// <inheritdoc cref="AbstractActionType.OnNewAction" />
+        /// <remarks>
+        /// With <see cref="AbstractActionType2"/> there is no need to override this method. <see cref="OnInstantiateAction"/>
+        /// will be called instead, with an empty Dictionary as parameter.
+        /// </remarks> 
+        protected override void OnNewAction() {
+            OnInstantiateAction(new Dictionary<string, string>());
+        }
+
+        /// <summary>
+        /// Called when an action of this type is being instantiated. Create the <see cref="AbstractActionType.ConfigPage"/> according
+        /// to the values passed as parameters. If no value is passed it means it's a new action, so initialize the
+        /// <see cref="AbstractActionType.ConfigPage"/> to the action's starting state so users can begin configuring it.
+        /// <para>
+        ///  Any JUI view added to the <see cref="AbstractActionType.ConfigPage"/> must use a unique ID as it will
+        ///  be displayed on an event page that could also be housing HTML from other plugins. It is recommended
+        ///  to use the <see cref="AbstractActionType.PageId"/> as a prefix for all views added to ensure that their IDs are unique.
+        /// </para>
+        /// <param name="viewIdValuePairs">View Id/Value pairs containing the existing values for this action</param>
+        /// </summary>
+        protected abstract void OnInstantiateAction(Dictionary<string, string> viewIdValuePairs);
+
+        internal override byte[] ProcessData(byte[] inData) {
+            //Is data null/empty?
+            if (inData == null || inData.Length == 0) {
+                return new byte[0];
+            }
+            
+            try {
+                //Get JSON string from byte[]
+                var valueMapJson = Encoding.UTF8.GetString(inData);
+                //Deserialize to values map
+                var valueMap = JsonConvert.DeserializeObject<Dictionary<string, string>>(valueMapJson);
+                //Call the plugin to build the ConfigPage
+                OnInstantiateAction(valueMap);
+                //Save the data
+                return inData;
+            }
+            catch (Exception exception) {
+                //Exception is expected if the data is version 1 type or legacy type
+                if (LogDebug) {
+                    Console.WriteLine($"Exception while trying to execute ProcessData on action data, possibly version 1 or legacy data - {exception.Message}");
+                }
+            }
+            
+            //If deserialization failed try to call the ProcessData method from AbstractActionType so that it is directly deserialized as the ConfigPage
+            return base.ProcessData(inData);
+        }
+
+        internal override byte[] GetData() {
+            var valueMap = ConfigPage?.ToValueMap() ?? new Dictionary<string, string>();
+            var valueMapJson = JsonConvert.SerializeObject(valueMap, Formatting.None);
+            return Encoding.UTF8.GetBytes(valueMapJson);
+        }
+    }
+
+}

--- a/Events/AbstractTriggerType2.cs
+++ b/Events/AbstractTriggerType2.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using HomeSeer.Jui.Types;
+using HomeSeer.Jui.Views;
+using HomeSeer.PluginSdk.Devices;
+using Newtonsoft.Json;
+
+namespace HomeSeer.PluginSdk.Events {
+
+    /// <summary>
+    /// The base implementation of a plugin trigger type available for users to select in HomeSeer
+    /// <para>
+    /// The difference between <see cref="AbstractTriggerType2"/> and <see cref="AbstractTriggerType"/>, is that with
+    /// <see cref="AbstractTriggerType2"/> only a collection of view Id/Value pairs is stored in database whereas with 
+    /// <see cref="AbstractTriggerType"/> the whole <see cref="AbstractTriggerType.ConfigPage"/> is stored. This allows 
+    /// the plugin to build the views in <see cref="OnInstantiateTrigger"/> every time a trigger is instantiated.
+    /// </para>
+    /// <para>
+    /// Inherit from this class to define your own trigger types and store them in your plugin's <see cref="TriggerTypeCollection"/>
+    /// </para>
+    /// </summary>
+    public abstract class AbstractTriggerType2 : AbstractTriggerType {
+
+        /// <summary>
+        /// Initialize a new <see cref="AbstractTriggerType2"/> with the specified ID, Event Ref, Data byte array, listener, and logDebug flag.
+        ///  The byte array will be automatically parsed to a collection of view Id/Value pairs, and <see cref="OnInstantiateTrigger"/> will be called.
+        /// <para>
+        /// This is called through reflection by the <see cref="TriggerTypeCollection"/> class if a class that
+        ///  derives from this type is added to its list.
+        /// </para>
+        /// <para>
+        /// You MUST implement one of these constructor signatures in any class that derives from <see cref="AbstractTriggerType2"/>
+        /// </para>
+        /// </summary>
+        /// <param name="id">The unique ID of this trigger in HomeSeer</param>
+        /// <param name="eventRef">The event reference ID that this trigger is associated with in HomeSeer</param>
+        /// <param name="selectedSubTriggerIndex">The 0 based index of the sub-trigger type selected for this trigger</param>
+        /// <param name="dataIn">A byte array containing the definition for a <see cref="Page"/></param>
+        /// <param name="listener">The listener that facilitates the communication with <see cref="AbstractPlugin"/></param>
+        /// <param name="logDebug">If true debug messages will be written to the console</param>
+        protected AbstractTriggerType2(int id, int eventRef, int selectedSubTriggerIndex, byte[] dataIn, TriggerTypeCollection.ITriggerTypeListener listener, bool logDebug = false)
+            : base(id, eventRef, selectedSubTriggerIndex, dataIn, listener, logDebug) {
+        }
+
+        /// <summary>
+        /// Initialize a new <see cref="AbstractTriggerType2"/> with the specified ID, Event Ref, Data byte array and listener.
+        ///  The byte array will be automatically parsed to a collection of view Id/Value pairs, and <see cref="OnInstantiateTrigger"/> will be called.
+        /// <para>
+        /// This is called through reflection by the <see cref="TriggerTypeCollection"/> class if a class that
+        ///  derives from this type is added to its list.
+        /// </para>
+        /// <para>
+        /// You MUST implement one of these constructor signatures in any class that derives from <see cref="AbstractTriggerType2"/>
+        /// </para>
+        /// </summary>
+        /// <param name="id">The unique ID of this trigger in HomeSeer</param>
+        /// <param name="eventRef">The event reference ID that this trigger is associated with in HomeSeer</param>
+        /// <param name="selectedSubTriggerIndex">The 0 based index of the sub-trigger type selected for this trigger</param>
+        /// <param name="dataIn">A byte array containing the definition for a <see cref="Page"/></param>
+        /// <param name="listener">The listener that facilitates the communication with <see cref="AbstractPlugin"/></param>
+        protected AbstractTriggerType2(int id, int eventRef, int selectedSubTriggerIndex, byte[] dataIn, TriggerTypeCollection.ITriggerTypeListener listener)
+        : base(id, eventRef, selectedSubTriggerIndex, dataIn, listener) {
+        }
+
+        /// <summary>
+        /// Initialize a new <see cref="AbstractTriggerType2"/> from a <see cref="TrigActInfo"/> and with the specified listener, and logDebug flag.
+        ///  The byte array in <paramref name="trigInfo"/> will be automatically parsed to a collection of view Id/Value pairs, 
+        ///  and <see cref="OnInstantiateTrigger"/> will be called.
+        /// <para>
+        /// This is called through reflection by the <see cref="TriggerTypeCollection"/> class if a class that
+        ///  derives from this type is added to its list.
+        /// </para>
+        /// <para>
+        /// You MUST implement one of these constructor signatures in any class that derives from <see cref="AbstractTriggerType2"/>
+        /// </para>
+        /// </summary>
+        /// <param name="trigInfo">The <see cref="TrigActInfo"/> containing all the trigger information</param>
+        /// <param name="listener">The listener that facilitates the communication with <see cref="AbstractPlugin"/></param>
+        /// <param name="logDebug">If true debug messages will be written to the console</param>
+        protected AbstractTriggerType2(TrigActInfo trigInfo, TriggerTypeCollection.ITriggerTypeListener listener, bool logDebug = false) :
+            base(trigInfo, listener, logDebug) {
+        }
+
+        /// <summary>
+        /// Initialize a new, unconfigured <see cref="AbstractTriggerType2"/>
+        /// <para>
+        /// This is called through reflection by the <see cref="TriggerTypeCollection"/> class if a class that
+        ///  derives from this type is added to its list.
+        /// </para>
+        /// </summary>
+        protected AbstractTriggerType2() : base() { }
+
+
+        /// <inheritdoc cref="AbstractTriggerType.OnNewTrigger" />
+        /// <remarks>
+        /// With <see cref="AbstractTriggerType2"/> there is no need to override this method. <see cref="OnInstantiateTrigger"/>
+        /// will be called instead, with an empty Dictionary as parameter.
+        /// </remarks> 
+        protected override void OnNewTrigger() {
+            OnInstantiateTrigger(new Dictionary<string, string>());
+        }
+
+
+        /// <summary>
+        /// Called when a trigger of this type is being instantiated. Create the <see cref="AbstractTriggerType.ConfigPage"/> according
+        /// to the values passed as parameters. If no value is passed it means it's a new trigger, so initialize the
+        /// <see cref="AbstractTriggerType.ConfigPage"/> to the trigger's starting state so users can begin configuring it.
+        /// <para>
+        ///  Any JUI view added to the <see cref="AbstractTriggerType.ConfigPage"/> must use a unique ID as it will
+        ///  be displayed on an event page that could also be housing HTML from other plugins. It is recommended
+        ///  to use the <see cref="AbstractTriggerType.PageId"/> as a prefix for all views added to ensure that their IDs are unique.
+        /// </para>
+        /// <param name="viewIdValuePairs">View Id/Value pairs containing the existing values for this trigger</param>
+        /// </summary>
+        protected abstract void OnInstantiateTrigger(Dictionary<string, string> viewIdValuePairs);
+
+        internal override byte[] ProcessData(byte[] inData) {
+            //Is data null/empty?
+            if (inData == null || inData.Length == 0) {
+                return new byte[0];
+            }
+
+            try {
+                //Get JSON string from byte[]
+                var valueMapJson = Encoding.UTF8.GetString(inData);
+                //Deserialize to values map
+                var valueMap = JsonConvert.DeserializeObject<Dictionary<string, string>>(valueMapJson);
+                //Call the plugin to build the ConfigPage
+                OnInstantiateTrigger(valueMap);
+                //Save the data
+                return inData;
+            }
+            catch (Exception exception) {
+                //Exception is expected if the data is version 1 type or legacy type
+                if (LogDebug) {
+                    Console.WriteLine($"Exception while trying to execute ProcessData on trigger data, possibly version 1 or legacy data - {exception.Message}");
+                }
+            }
+
+            //If deserialization failed, try to call the ProcessData method from AbstractTriggerType so that it is directly deserialized as the ConfigPage
+            return base.ProcessData(inData);
+        }
+
+        internal override byte[] GetData() {
+            var valueMap = ConfigPage?.ToValueMap() ?? new Dictionary<string, string>();
+            var valueMapJson = JsonConvert.SerializeObject(valueMap, Formatting.None);
+            return Encoding.UTF8.GetBytes(valueMapJson);
+        }
+
+    }
+
+}

--- a/Jui/Views/AbstractView.cs
+++ b/Jui/Views/AbstractView.cs
@@ -5,151 +5,156 @@ using Newtonsoft.Json;
 
 namespace HomeSeer.Jui.Views {
 
-	/// <summary>
-	/// The base implementation of a JUI view
-	/// </summary>
-	public abstract class AbstractView {
+    /// <summary>
+    /// The base implementation of a JUI view
+    /// </summary>
+    public abstract class AbstractView {
 
-		/// <summary>
-		/// A unique identifier for this view.  You will need to use this to identify the view when HomeSeer 
-		/// communicates changes to its values from a client.
-		/// <para>
-		/// Do NOT use any of the following special characters in your view id: <![CDATA[!"#$%&'()*+,./:;<=>?@[]^`{|}~]]>
-		/// For consistency and readability it is advised to use the format of COMPANY-PLUGIN-PAGE-VIEW
-		/// </para>
-		/// <para>
-		/// For example: a LabelView on the first settings page in the Z-Wave Plugin
-		/// might have an id of HomeSeer-ZWave-Settings1-InterfaceName
-		/// </para>
-		/// </summary>
-		[JsonProperty("id", Required = Required.Always)]
-		public string Id { get; protected set; }
-		
-		/// <summary>
-		/// The name/title of this view
-		/// </summary>
-		[JsonProperty("name")]
-		public string Name { get; protected set; }
-		
-		/// <summary>
-		/// The type of this view.
-		/// <para>
-		/// This is automatically configured
-		/// </para>
-		/// </summary>
-		[JsonProperty("type", Required = Required.Always)]
-		public EViewType Type { get; protected set; }
+        /// <summary>
+        /// A unique identifier for this view.  You will need to use this to identify the view when HomeSeer 
+        /// communicates changes to its values from a client.
+        /// <para>
+        /// Do NOT use any of the following special characters in your view id: <![CDATA[!"#$%&'()*+,./:;<=>?@[]^`{|}~]]>
+        /// For consistency and readability it is advised to use the format of COMPANY-PLUGIN-PAGE-VIEW
+        /// </para>
+        /// <para>
+        /// For example: a LabelView on the first settings page in the Z-Wave Plugin
+        /// might have an id of HomeSeer-ZWave-Settings1-InterfaceName
+        /// </para>
+        /// </summary>
+        [JsonProperty("id", Required = Required.Always)]
+        public string Id { get; protected set; }
 
-		/// <summary>
-		/// Represents a tab/indent for formatting HTML
-		/// </summary>
-		[JsonIgnore] private const string HtmlIndent = "    ";
+        /// <summary>
+        /// The name/title of this view
+        /// </summary>
+        [JsonProperty("name")]
+        public string Name { get; protected set; }
 
-		/// <summary>
-		/// The list of special characters that are not allowed in a view ID
-		/// </summary>
-		[JsonIgnore] private static readonly char[] NonAllowedCharactersForId = "!\"#$%&'()*+,./:;<=>?@[]^`{|}~".ToCharArray();
+        /// <summary>
+        /// The type of this view.
+        /// <para>
+        /// This is automatically configured
+        /// </para>
+        /// </summary>
+        [JsonProperty("type", Required = Required.Always)]
+        public EViewType Type { get; protected set; }
 
-		/// <summary>
-		/// Create an instance of an AbstractView with an ID
-		/// </summary>
-		/// <param name="id">The unique ID for the AbstractView</param>
-		/// <exception cref="ArgumentNullException">Thrown if a view is created with an invalid ID</exception>
-		protected AbstractView(string id) {
-			if (string.IsNullOrWhiteSpace(id)) {
-				throw new ArgumentNullException(nameof(id));
-			}
-			
-			Id = id;
-		}
-		
-		/// <summary>
-		/// Create an instance of an AbstractView with an ID and Name
-		/// </summary>
-		/// <param name="id">The unique ID for the AbstractView</param>
-		/// <param name="name">The name for the AbstractView</param>
-		/// <exception cref="ArgumentNullException">Thrown if a view is created with an invalid ID</exception>
-		protected AbstractView(string id, string name) {
-			if (string.IsNullOrWhiteSpace(id)) {
-				throw new ArgumentNullException(nameof(id));
-			}
-			
-			Id = id;
-			Name = name;
-		}
+        /// <summary>
+        /// Represents a tab/indent for formatting HTML
+        /// </summary>
+        [JsonIgnore] private const string HtmlIndent = "    ";
 
-		/// <summary>
-		/// Get the value associated with this view as a string if there is one.
-		/// </summary>
-		/// <returns>
-		/// The value stored in this view as a string or NULL if there is no value stored.
-		/// </returns>
-		public abstract string GetStringValue();
+        /// <summary>
+        /// The list of special characters that are not allowed in a view ID
+        /// </summary>
+        [JsonIgnore] private static readonly char[] NonAllowedCharactersForId = "!\"#$%&'()*+,./:;<=>?@[]^`{|}~".ToCharArray();
 
-		/// <summary>
-		/// Update the the user editable properties from a new version of the same view
-		/// </summary>
-		/// <param name="newViewState">
-		/// The new state of the view being updated.
-		/// This view's ID and Type must match the calling view exactly
-		/// </param>
-		/// <exception cref="ArgumentNullException">Thrown when the new state of the view is null</exception>
-		/// <exception cref="InvalidOperationException">Thrown when the new view's ID or Type don't match the calling view</exception>
-		public virtual void Update(AbstractView newViewState) {
+        /// <summary>
+        /// Create an instance of an AbstractView with an ID
+        /// </summary>
+        /// <param name="id">The unique ID for the AbstractView</param>
+        /// <exception cref="ArgumentNullException">Thrown if a view is created with an invalid ID</exception>
+        protected AbstractView(string id) {
+            if (string.IsNullOrWhiteSpace(id)) {
+                throw new ArgumentNullException(nameof(id));
+            }
 
-			if (newViewState == null) {
-				throw new ArgumentNullException(nameof(newViewState));
-			}
-
-			if (newViewState.Id != Id) {
-				throw new InvalidOperationException("The ID of the update does not match the ID of the original view");
-			}
-
-			if (newViewState.Type != Type) {
-				throw new InvalidOperationException("The original view type does not match the type in the update");
-			}
-
-		}
-
-		/// <summary>
-		/// Update the value of the view
-		/// </summary>
-		/// <param name="value">The new value</param>
-		public virtual void UpdateValue(string value) {
-			
-		}
-
-		/// <summary>
-		/// Get a string representation of this view converted into HTML
-		/// </summary>
-		/// <returns>An HTML representation of the view as a string</returns>
-		public abstract string ToHtml(int indent = 0);
-
-		/// <summary>
-		/// Used to generate the exact tab spacing (using spaces) for any given indent amount
-		/// </summary>
-		/// <param name="indent">The number of indents for the line</param>
-		/// <returns>A string containing the number of spaces to achieve the desired indent</returns>
-		public static string GetIndentStringFromNumber(int indent) {	
-			
-			var indentString = new StringBuilder("");
-			
-			for (var i = 0; i < indent; i++) {
-				indentString.Append(HtmlIndent);
-			}
-
-			return indentString.ToString();
-		}
-
-		/// <summary>
-		/// Used to check if the view ID contains non-allowed characters
-		/// </summary>
-		/// <returns>True if view ID contains at least one non-allowed characters, False otherwise</returns>
-		public bool IdContainsNonAllowedCharacters()
-        {
-			return Id.IndexOfAny(NonAllowedCharactersForId) >= 0;
+            Id = id;
         }
 
-	}
+        /// <summary>
+        /// Create an instance of an AbstractView with an ID and Name
+        /// </summary>
+        /// <param name="id">The unique ID for the AbstractView</param>
+        /// <param name="name">The name for the AbstractView</param>
+        /// <exception cref="ArgumentNullException">Thrown if a view is created with an invalid ID</exception>
+        protected AbstractView(string id, string name) {
+            if (string.IsNullOrWhiteSpace(id)) {
+                throw new ArgumentNullException(nameof(id));
+            }
 
+            Id = id;
+            Name = name;
+        }
+
+        /// <summary>
+        /// Get the value associated with this view as a string if there is one.
+        /// </summary>
+        /// <returns>
+        /// The value stored in this view as a string or NULL if there is no value stored.
+        /// </returns>
+        public abstract string GetStringValue();
+
+        /// <summary>
+        /// Update the the user editable properties from a new version of the same view
+        /// </summary>
+        /// <param name="newViewState">
+        /// The new state of the view being updated.
+        /// This view's ID and Type must match the calling view exactly
+        /// </param>
+        /// <exception cref="ArgumentNullException">Thrown when the new state of the view is null</exception>
+        /// <exception cref="InvalidOperationException">Thrown when the new view's ID or Type don't match the calling view</exception>
+        public virtual void Update(AbstractView newViewState) {
+
+            if (newViewState == null) {
+                throw new ArgumentNullException(nameof(newViewState));
+            }
+
+            if (newViewState.Id != Id) {
+                throw new InvalidOperationException("The ID of the update does not match the ID of the original view");
+            }
+
+            if (newViewState.Type != Type) {
+                throw new InvalidOperationException("The original view type does not match the type in the update");
+            }
+
+        }
+
+        /// <summary>
+        /// Update the value of the view
+        /// </summary>
+        /// <param name="value">The new value</param>
+        public virtual void UpdateValue(string value) {
+
+        }
+
+        /// <summary>
+        /// Get a string representation of this view converted into HTML
+        /// </summary>
+        /// <returns>An HTML representation of the view as a string</returns>
+        public abstract string ToHtml(int indent = 0);
+
+        /// <summary>
+        /// Used to generate the exact tab spacing (using spaces) for any given indent amount
+        /// </summary>
+        /// <param name="indent">The number of indents for the line</param>
+        /// <returns>A string containing the number of spaces to achieve the desired indent</returns>
+        public static string GetIndentStringFromNumber(int indent) {
+
+            var indentString = new StringBuilder("");
+
+            for (var i = 0; i < indent; i++) {
+                indentString.Append(HtmlIndent);
+            }
+
+            return indentString.ToString();
+        }
+
+        /// <summary>
+        /// Used to check if the view ID contains non-allowed characters
+        /// </summary>
+        /// <returns>True if view ID contains at least one non-allowed characters, False otherwise</returns>
+        public bool IdContainsNonAllowedCharacters() {
+            return Id.IndexOfAny(NonAllowedCharactersForId) >= 0;
+        }
+
+        /// <summary>
+        /// Create a shallow copy of this view
+        /// </summary>
+        /// <returns>The shallow copy of the view</returns>
+        public AbstractView ShallowCopy() {
+            return (AbstractView)this.MemberwiseClone();
+        }
+    }
 }

--- a/Jui/Views/EColSize.cs
+++ b/Jui/Views/EColSize.cs
@@ -1,71 +1,69 @@
 namespace HomeSeer.Jui.Views {
 
-	/// <summary>
-	/// The poissible sizes for a column in the <a href="https://mdbootstrap.com/docs/standard/layout/grid/">bootstrap grid system</a>
-	/// </summary>
-	public enum EColSize 
-	{
-		/// <summary>
-		/// None
-		/// </summary>
-		None = -1,
-		/// <summary>
-		/// Equal-width column
-		/// </summary>
-		Col = 0,
-		/// <summary>
-		/// Column of size 1
-		/// </summary>
-		Col1 = 1,
-		/// <summary>
-		/// Column of size 2
-		/// </summary>
-		Col2 = 2,
-		/// <summary>
-		/// Column of size 3
-		/// </summary>
-		Col3 = 3,
-		/// <summary>
-		/// Column of size 4
-		/// </summary>
-		Col4 = 4,
-		/// <summary>
-		/// Column of size 5
-		/// </summary>
-		Col5 = 5,
-		/// <summary>
-		/// Column of size 6
-		/// </summary>
-		Col6 = 6,
-		/// <summary>
-		/// Column of size 7
-		/// </summary>
-		Col7 = 7,
-		/// <summary>
-		/// Column of size 8
-		/// </summary>
-		Col8 = 8,
-		/// <summary>
-		/// Column of size 9
-		/// </summary>
-		Col9 = 9,
-		/// <summary>
-		/// Column of size 10
-		/// </summary>
-		Col10 = 10,
-		/// <summary>
-		/// Column of size 11
-		/// </summary>
-		Col11 = 11,
-		/// <summary>
-		/// Column of size 12
-		/// </summary>
-		Col12 = 12,
-		/// <summary>
-		/// Size based on the natural width of their content
-		/// </summary>
-		Auto = 13,
-
-	}
+    /// <summary>
+    /// The possible sizes for a column in the <a href="https://mdbootstrap.com/docs/standard/layout/grid/">bootstrap grid system</a>
+    /// </summary>
+    public enum EColSize {
+        /// <summary>
+        /// None
+        /// </summary>
+        None = -1,
+        /// <summary>
+        /// Equal-width column
+        /// </summary>
+        Col = 0,
+        /// <summary>
+        /// Column of size 1
+        /// </summary>
+        Col1 = 1,
+        /// <summary>
+        /// Column of size 2
+        /// </summary>
+        Col2 = 2,
+        /// <summary>
+        /// Column of size 3
+        /// </summary>
+        Col3 = 3,
+        /// <summary>
+        /// Column of size 4
+        /// </summary>
+        Col4 = 4,
+        /// <summary>
+        /// Column of size 5
+        /// </summary>
+        Col5 = 5,
+        /// <summary>
+        /// Column of size 6
+        /// </summary>
+        Col6 = 6,
+        /// <summary>
+        /// Column of size 7
+        /// </summary>
+        Col7 = 7,
+        /// <summary>
+        /// Column of size 8
+        /// </summary>
+        Col8 = 8,
+        /// <summary>
+        /// Column of size 9
+        /// </summary>
+        Col9 = 9,
+        /// <summary>
+        /// Column of size 10
+        /// </summary>
+        Col10 = 10,
+        /// <summary>
+        /// Column of size 11
+        /// </summary>
+        Col11 = 11,
+        /// <summary>
+        /// Column of size 12
+        /// </summary>
+        Col12 = 12,
+        /// <summary>
+        /// Size based on the natural width of their content
+        /// </summary>
+        Auto = 13,
+    }
 
 }

--- a/Jui/Views/EHorizontalAlignment.cs
+++ b/Jui/Views/EHorizontalAlignment.cs
@@ -1,0 +1,33 @@
+namespace HomeSeer.Jui.Views {
+
+    /// <summary>
+    /// The possible behaviors for the horizontal alignment of items in a row 
+    /// </summary>
+    public enum EHorizontalAlignment {
+        /// <summary>
+        /// None
+        /// </summary>
+        None = -1,
+        /// <summary>
+        /// Items are packed towards the start of the row
+        /// </summary>
+        JustifyContentStart = 0,
+        /// <summary>
+        /// Items are packed towards the end of the row
+        /// </summary>
+        JustifyContentEnd = 1,
+        /// <summary>
+        /// Items are centered along the row
+        /// </summary>
+        JustifyContentCenter = 2,
+        /// <summary>
+        /// Items are evenly distributed in the row with equal space around them
+        /// </summary>
+        JustifyContentAround = 3,
+        /// <summary>
+        /// Items are evenly distributed in the row; first item is on the start of the row, last item on the end of the row
+        /// </summary>
+        JustifyContentBetween = 4,
+    }
+
+}

--- a/Jui/Views/EVerticalAlignment.cs
+++ b/Jui/Views/EVerticalAlignment.cs
@@ -1,0 +1,25 @@
+namespace HomeSeer.Jui.Views {
+
+    /// <summary>
+    /// The possible behaviors for the vertical alignment of items in a row 
+    /// </summary>
+    public enum EVerticalAlignment {
+        /// <summary>
+        /// None
+        /// </summary>
+        None = -1,
+        /// <summary>
+        /// Items are placed at the top of the row
+        /// </summary>
+        AlignItemsStart = 0,
+        /// <summary>
+        /// Items are placed at the bottom of the row
+        /// </summary>
+        AlignItemsEnd = 1,
+        /// <summary>
+        /// Items are centered in the row
+        /// </summary>
+        AlignItemsCenter = 2,
+    }
+
+}

--- a/Jui/Views/GridRow.cs
+++ b/Jui/Views/GridRow.cs
@@ -6,100 +6,142 @@ using System.Linq;
 using System.Text;
 using Newtonsoft.Json;
 
-namespace HomeSeer.Jui.Views 
-{
-	/// <summary>
-	/// A set of views that are displayed as a flexbox row within a <see cref="GridView"/>
-	/// </summary>
-	public class GridRow
-	{
-		#region Properties
+namespace HomeSeer.Jui.Views {
+    /// <summary>
+    /// A set of views that are displayed as a flexbox row within a <see cref="GridView"/>
+    /// </summary>
+    public class GridRow {
+        #region Properties
 
-		/// <summary>
-		/// The views to display within this row. This is for access only.
-		/// </summary>
-		[JsonIgnore]
-		public ReadOnlyCollection<AbstractView> Views => _items.ConvertAll( x => x.View).AsReadOnly();
+        /// <summary>
+        /// The views to display within this row. This is for access only.
+        /// </summary>
+        [JsonIgnore]
+        public ReadOnlyCollection<AbstractView> Views => _items.ConvertAll(x => x.View).AsReadOnly();
 
-		/// <summary>
-		/// The items to display within this row.
-		/// </summary>
-		[JsonProperty("items")] 
-		private List<GridRowItem> _items;
-		
+        /// <summary>
+        /// The  <a href="https://getbootstrap.com/docs/4.0/layout/grid/#horizontal-alignment">horizontal alignment</a> of the items in the row
+        /// </summary>
+        [JsonProperty("horizontal_alignment")]
+        public EHorizontalAlignment HorizontalAlignment { get; set; }
 
-		#endregion
+        /// <summary>
+        /// The  <a href="https://getbootstrap.com/docs/4.0/layout/grid/#vertical-alignment">vertical alignment</a> of the items in the row
+        /// </summary>
+        [JsonProperty("vertical_alignment")]
+        public EVerticalAlignment VerticalAlignment { get; set; }
 
-		#region Constructors
+        /// <summary>
+        /// The items to display within this row.
+        /// </summary>
+        [JsonProperty("items")]
+        private List<GridRowItem> _items;
 
-		/// <summary>
-		/// Create a new instance of a view group row
-		/// </summary>
-		[JsonConstructor]
-		public GridRow() 
-		{
-			_items = new List<GridRowItem>();
-		}
-		
-		#endregion
-		
-		#region Items
-		
-		#region Add
 
-		/// <summary>
-		/// Add an item to the row
-		/// </summary>
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Create a new instance of a view group row
+        /// </summary>
+        [JsonConstructor]
+        public GridRow() {
+            _items = new List<GridRowItem>();
+        }
+
+        #endregion
+
+        #region Items
+
+        #region Add
+
+        /// <summary>
+        /// Add an item to the row
+        /// </summary>
         /// <exception cref="ArgumentNullException">Thrown when the specified view or its ID is null</exception>
         public void AddItem(AbstractView view,
-							EColSize extraSmallSize = EColSize.Col,
-							EColSize smallSize = EColSize.None,
-							EColSize mediumSize = EColSize.None,
-							EColSize largeSize = EColSize.None,
-							EColSize extraLargeSize = EColSize.None) 
-		{
-			if (view?.Id == null)
-			{
-				throw new ArgumentNullException(nameof(view), "The view or its ID is null");
-			}
-			_items.Add(new GridRowItem(view, extraSmallSize, smallSize, mediumSize, largeSize, extraLargeSize));
-		}
+                            EColSize extraSmallSize = EColSize.Col,
+                            EColSize smallSize = EColSize.None,
+                            EColSize mediumSize = EColSize.None,
+                            EColSize largeSize = EColSize.None,
+                            EColSize extraLargeSize = EColSize.None) {
+            if (view?.Id == null) {
+                throw new ArgumentNullException(nameof(view), "The view or its ID is null");
+            }
+            _items.Add(new GridRowItem(view, extraSmallSize, smallSize, mediumSize, largeSize, extraLargeSize));
+        }
 
-		#endregion
+        #endregion
 
-		#endregion
+        #endregion
 
-		/// <summary>
-		/// Get a string representation of this grid row converted into HTML
-		/// </summary>
-		/// <returns>An HTML representation of the view as a string</returns>
-		public string ToHtml(int indent = 0)
-		{
-			var sb = new StringBuilder();
-			sb.Append(AbstractView.GetIndentStringFromNumber(indent));
-			//Open the containing div
-			sb.Append("<div class=\"row\">");
-			sb.Append(Environment.NewLine);
-			//Add items
-			foreach (var item in _items)
-			{
-				sb.Append(AbstractView.GetIndentStringFromNumber(indent + 1));
-				sb.Append("<div class=\"");
-				sb.Append(item.GetHtmlDivClass());
-				sb.Append("\">");
-				sb.Append(Environment.NewLine);
-				sb.Append(item.View.ToHtml(indent + 2));
-				sb.Append(AbstractView.GetIndentStringFromNumber(indent + 1));
-				sb.Append("</div>");
-				sb.Append(Environment.NewLine);
-			}
-			//Close the containing div
-			sb.Append(AbstractView.GetIndentStringFromNumber(indent));
-			sb.Append("</div>");
-			sb.Append(Environment.NewLine);
+        private string GetHorizontalAlignmentClass() {
+            switch (HorizontalAlignment) {
+                case EHorizontalAlignment.JustifyContentStart:
+                    return "justify-content-start";
+                case EHorizontalAlignment.JustifyContentEnd:
+                    return "justify-content-end";
+                case EHorizontalAlignment.JustifyContentCenter:
+                    return "justify-content-center";
+                case EHorizontalAlignment.JustifyContentAround:
+                    return "justify-content-around";
+                case EHorizontalAlignment.JustifyContentBetween:
+                    return "justify-content-between";
+                default:
+                    return "";
+            }
+        }
 
-			return sb.ToString();
-		}
-	}
+        private string GetVerticalAlignmentClass() {
+            switch (VerticalAlignment) {
+                case EVerticalAlignment.AlignItemsStart:
+                    return "align-items-start";
+                case EVerticalAlignment.AlignItemsEnd:
+                    return "align-items-end";
+                case EVerticalAlignment.AlignItemsCenter:
+                    return "align-items-center";
+                default:
+                    return "";
+            }
+        }
+
+        /// <summary>
+        /// Get a string representation of this grid row converted into HTML
+        /// </summary>
+        /// <returns>An HTML representation of the view as a string</returns>
+        public string ToHtml(int indent = 0) {
+            var sb = new StringBuilder();
+            sb.Append(AbstractView.GetIndentStringFromNumber(indent));
+            //Open the containing div
+            sb.Append("<div class=\"row");
+            if (HorizontalAlignment != EHorizontalAlignment.None) {
+                sb.Append($" {GetHorizontalAlignmentClass()}");
+            }
+            if (VerticalAlignment != EVerticalAlignment.None) {
+                sb.Append($" {GetVerticalAlignmentClass()}");
+            }
+            sb.Append("\">");
+            sb.Append(Environment.NewLine);
+            //Add items
+            foreach (var item in _items) {
+                sb.Append(AbstractView.GetIndentStringFromNumber(indent + 1));
+                sb.Append("<div class=\"");
+                sb.Append(item.GetHtmlDivClass());
+                sb.Append("\">");
+                sb.Append(Environment.NewLine);
+                sb.Append(item.View.ToHtml(indent + 2));
+                sb.Append(AbstractView.GetIndentStringFromNumber(indent + 1));
+                sb.Append("</div>");
+                sb.Append(Environment.NewLine);
+            }
+            //Close the containing div
+            sb.Append(AbstractView.GetIndentStringFromNumber(indent));
+            sb.Append("</div>");
+            sb.Append(Environment.NewLine);
+
+            return sb.ToString();
+        }
+    }
 
 }

--- a/Jui/Views/GridRowItem.cs
+++ b/Jui/Views/GridRowItem.cs
@@ -20,7 +20,7 @@ namespace HomeSeer.Jui.Views
 		/// <summary>
 		/// The view to display.
 		/// </summary>
-		[JsonProperty("view")] 
+		[JsonProperty("view", IsReference = true)] 
 		public AbstractView View { get; set; }
 
 		/// <summary>

--- a/Jui/Views/GridView.cs
+++ b/Jui/Views/GridView.cs
@@ -132,7 +132,7 @@ namespace HomeSeer.Jui.Views
             //Open the containing div
             sb.Append("<div id=\"");
             sb.Append(Id);
-            sb.Append("\" class=\"jui-view jui-group container\">");
+            sb.Append("\" class=\"jui-view jui-group\">");
             sb.Append(Environment.NewLine);
             //Add the title
             sb.Append(GetIndentStringFromNumber(indent + 1));

--- a/Jui/Views/SelectListView.cs
+++ b/Jui/Views/SelectListView.cs
@@ -60,6 +60,13 @@ namespace HomeSeer.Jui.Views {
 		[JsonProperty("default_selection_text")]
 		public string DefaultSelectionText { get; set; }
 
+        /// <summary>
+        /// When this property is true, <see cref="GetStringValue"/>  returns the selected option key instead of the selected option index,
+        /// and <see cref="UpdateValue"/> expects an option key as parameter instead of an option index.
+        /// </summary>
+        [JsonProperty("use_option_key_as_selection_value")]
+        public bool UseOptionKeyAsSelectionValue { get; set; } = false;
+
 		/// <inheritdoc cref="AbstractView"/>
 		/// <summary>
 		/// Create a new instance of a select list with the default, drop down style, an ID, Name, and the specified list of options
@@ -137,32 +144,47 @@ namespace HomeSeer.Jui.Views {
 			Selection = updatedSelectListView.Selection;
 		}
 
-		/// <inheritdoc cref="AbstractView.UpdateValue"/>
-		/// <exception cref="FormatException">Thrown when the value is not in the correct format</exception>
-		public override void UpdateValue(string value) {
+        /// <inheritdoc cref="AbstractView.UpdateValue"/>
+        /// <exception cref="FormatException">Thrown when the value is not in the correct format</exception>
+        public override void UpdateValue(string value) {
 
-			try {
-				Selection = int.Parse(value);
-			}
-			catch (Exception exception) {
-				Console.WriteLine(exception);
-				throw new FormatException("Value is not in the correct format", exception);
-			}
-		}
+            if (UseOptionKeyAsSelectionValue) {
+                if (OptionKeys != null) {
+                    Selection = OptionKeys.FindIndex(x => x == value);
+                }
+                else {
+                    Selection = -1;
+                }
+            }
+            else {
+                try {
+                    Selection = int.Parse(value);
+                }
+                catch (Exception exception) {
+                    Console.WriteLine(exception);
+                    throw new FormatException("Value is not in the correct format", exception);
+                }
+            }
+        }
 
-		/// <inheritdoc cref="AbstractView.GetStringValue"/>
-		/// <remarks>
-		/// Get the selected index as a string
-		/// </remarks>
-		public override string GetStringValue() {
-			return Selection.ToString();
-		}
+        /// <inheritdoc cref="AbstractView.GetStringValue"/>
+        /// <remarks>
+        /// Returns the selected option key if <see cref="UseOptionKeyAsSelectionValue"/> is true, else returns the selected index as a string
+        /// </remarks>
+        public override string GetStringValue() {
+            if (UseOptionKeyAsSelectionValue) {
+                return GetSelectedOptionKey();
+            }
+            else {
+                return Selection.ToString();
+            }
+        }
 
-		/// <summary>
-		/// Get the currently selected option text.
-		/// </summary>
-		/// <returns>The text of the option at the index specified by <see cref="Selection"/>.</returns>
-		public string GetSelectedOption() {
+        /// <summary>
+        /// Get the currently selected option text.
+        /// </summary>
+        /// <returns>The text of the option at the index specified by <see cref="Selection"/>.</returns>
+        public string GetSelectedOption() {
 			if (Options == null || Selection >= Options.Count || Selection == -1) {
 				return string.Empty;
 			}
@@ -198,12 +220,24 @@ namespace HomeSeer.Jui.Views {
 			switch (Style) {
 				case ESelectListType.DropDown:
                 case ESelectListType.SearchableDropDown:
+                    string originalValue;
+                    if (UseOptionKeyAsSelectionValue) {
+                        if (OptionKeys != null && Selection >= 0 && Selection < OptionKeys.Count) {
+                            originalValue = OptionKeys[Selection];
+                        }
+                        else {
+                            originalValue = "";
+                        }
+                    }
+                    else {
+                        originalValue = Selection.ToString();
+                    }
                     //Add the title
                     sb.Append($"<label class=\"jui-select-label\">{Name}</label>");
 					sb.Append(Environment.NewLine);
 					//Add the button
 					sb.Append(GetIndentStringFromNumber(indent+1));
-					sb.Append($"<select class=\"mdb-select md-form jui-input jui-select\" id=\"{Id}\" jui-orig-val=\"{Selection}\" {(Style== ESelectListType.SearchableDropDown ? "searchable=\"Search...\"" : "")}>");
+					sb.Append($"<select class=\"mdb-select md-form jui-input jui-select\" id=\"{Id}\" jui-orig-val=\"{originalValue}\" {(Style== ESelectListType.SearchableDropDown ? "searchable=\"Search...\"" : "")}>");
 					sb.Append(Environment.NewLine);
 					sb.Append(GetIndentStringFromNumber(indent+2));
 					sb.Append($"<option value=\"\" disabled {(Selection == -1 ? "selected" : "")}>");
@@ -212,8 +246,12 @@ namespace HomeSeer.Jui.Views {
 					sb.Append(Environment.NewLine);
 					for (var i = 0; i < Options.Count; i++) {
 						var option = Options[i];
+                        string optionValue = i.ToString();
+                        if (UseOptionKeyAsSelectionValue && OptionKeys != null && i < OptionKeys.Count) {
+                            optionValue = OptionKeys[i];
+                        }
 						sb.Append(GetIndentStringFromNumber(indent+2));
-						sb.Append($"<option value=\"{i}\"{(i == Selection ? " selected" : "")}>{option}</option>");
+						sb.Append($"<option value=\"{optionValue}\"{(i == Selection ? " selected" : "")}>{option}</option>");
 						sb.Append(Environment.NewLine);
 					}
 					sb.Append(GetIndentStringFromNumber(indent+1));
@@ -257,7 +295,11 @@ namespace HomeSeer.Jui.Views {
 					for (var optionNum = 0; optionNum < Options.Count; optionNum++) {
 						var option = Options[optionNum];
 						var optionId = $"{Id}-{optionNum}";
-						sb.Append(GetIndentStringFromNumber(indent+2));
+                        string optionValue = optionNum.ToString();
+                        if (UseOptionKeyAsSelectionValue && OptionKeys != null && optionNum < OptionKeys.Count) {
+                            optionValue = OptionKeys[optionNum];
+                        }
+                        sb.Append(GetIndentStringFromNumber(indent+2));
 						sb.Append("<div class=\"jui-toggle jui-selectlist-radio-option\">");
 						sb.Append(Environment.NewLine);
 						sb.Append(GetIndentStringFromNumber(indent+3));
@@ -265,7 +307,7 @@ namespace HomeSeer.Jui.Views {
 						sb.Append(Environment.NewLine);
 						sb.Append(GetIndentStringFromNumber(indent+3));
 						sb.Append("<span class=\"form-check jui-toggle-control\">");
-						sb.Append($"<input type=\"radio\" id=\"{optionId}\" par-id=\"{Id}-par\" class=\"form-check-input jui-input\" name=\"{Id}\" {(optionNum == Selection ? "checked" : "")} value=\"{optionNum}\">");
+						sb.Append($"<input type=\"radio\" id=\"{optionId}\" par-id=\"{Id}-par\" class=\"form-check-input jui-input\" name=\"{Id}\" {(optionNum == Selection ? "checked" : "")} value=\"{optionValue}\">");
 						sb.Append($"<label class=\"form-check-label jui-toggle-checkbox-label\" for=\"{optionId}\"/></span>");
 						sb.Append(Environment.NewLine);
 						sb.Append(GetIndentStringFromNumber(indent+2));

--- a/Jui/Views/SettingsCollection.cs
+++ b/Jui/Views/SettingsCollection.cs
@@ -366,6 +366,9 @@ namespace HomeSeer.Jui.Views {
 		                                                       new JsonSerializerSettings
 		                                                       { TypeNameHandling = TypeNameHandling.Auto }
 		                                                      );
+                foreach(var page in collection.AllPages) {
+                    page.MapViewIds();
+                }
 				
 		        return collection;
 	        }

--- a/Jui/Views/ViewGroup.cs
+++ b/Jui/Views/ViewGroup.cs
@@ -39,7 +39,7 @@ namespace HomeSeer.Jui.Views {
 		/// <summary>
 		/// The views to display within this group.
 		/// </summary>
-		[JsonProperty("views")] 
+		[JsonProperty("views", ItemIsReference = true)] 
 		private List<AbstractView> _views;
 		
 		/// <summary>

--- a/PluginSdk.csproj
+++ b/PluginSdk.csproj
@@ -119,7 +119,9 @@
     <Compile Include="Devices\ValueRange.cs" />
     <Compile Include="Devices\StatusGraphic.cs" />
     <Compile Include="Events\AbstractActionType.cs" />
+    <Compile Include="Events\AbstractActionType2.cs" />
     <Compile Include="Events\AbstractTriggerType.cs" />
+    <Compile Include="Events\AbstractTriggerType2.cs" />
     <Compile Include="Events\ActionTypeCollection.cs" />
     <Compile Include="Events\BaseTypeCollection.cs" />
     <Compile Include="Events\EEventFlag.cs" />
@@ -155,6 +157,8 @@
     <Compile Include="IHsController.cs" />
     <Compile Include="Jui\Types\ELabelType.cs" />
     <Compile Include="Jui\Views\EColSize.cs" />
+    <Compile Include="Jui\Views\EHorizontalAlignment.cs" />
+    <Compile Include="Jui\Views\EVerticalAlignment.cs" />
     <Compile Include="Jui\Views\GridView.cs" />
     <Compile Include="Jui\Views\GridRow.cs" />
     <Compile Include="Jui\Views\GridRowItem.cs" />

--- a/PluginSdk.nuspec
+++ b/PluginSdk.nuspec
@@ -2,7 +2,7 @@
 <package >
     <metadata>
         <id>HomeSeer-PluginSDK</id>
-        <version>1.4.2.0</version>
+        <version>1.4.3.0</version>
         <title>HomeSeer PluginSDK</title>
         <authors>HomeSeer</authors>
         <owners>HomeSeer</owners>
@@ -13,7 +13,7 @@
         <icon>images\icon-hs-128.png</icon>
         <license type="expression">AGPL-3.0-or-later</license>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
-        <releaseNotes>https://homeseer.github.io/Plugin-SDK-Docs/release_notes/pluginsdk_releasenotes_1_4_2_0.html</releaseNotes>
+        <releaseNotes>https://homeseer.github.io/Plugin-SDK-Docs/release_notes/pluginsdk_releasenotes_1_4_3_0.html</releaseNotes>
         <copyright>Copyright 2022</copyright>
         <tags>HomeSeer Home Seer Plugin pluginsdk hs4 sdk hs api pluginapi plugins smart auto automation control monitor</tags>
         <dependencies>

--- a/PluginSdkTests/Events/AbstractActionType2Tests.cs
+++ b/PluginSdkTests/Events/AbstractActionType2Tests.cs
@@ -1,0 +1,239 @@
+using HomeSeer.Jui.Views;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using NUnit.Framework.Internal;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace HomeSeer.PluginSdk.Events {
+
+    [TestFixture(
+        TestOf = typeof(AbstractActionType2),
+        Description = "Tests of the AbstractActionType2 class to ensure it behaves as expected under normal conditions.")]
+    public class AbstractActionType2Tests {
+        
+        private static readonly Randomizer RANDOMIZER = Randomizer.CreateRandomizer();
+
+        private static IEnumerable<bool> ValidBoolTestCaseSource() {
+            yield return false;
+            yield return true;
+        }
+
+        private static IEnumerable<object[]> ValidConstructor4ParamTestCaseSource() {
+            yield return new object[] {
+                RANDOMIZER.NextShort(),
+                RANDOMIZER.NextShort(),
+                Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(new Dictionary<string, string>() { { "viewId", "viewValue" } }, Formatting.None)),
+                null
+            };
+            yield return new object[] {
+                RANDOMIZER.NextShort(), 
+                RANDOMIZER.NextShort(), 
+                Encoding.UTF8.GetBytes(
+                    PageFactory.CreateEventActionPage(
+                        RANDOMIZER.GetString(), 
+                        RANDOMIZER.GetString()).Page.ToJsonString()), 
+                null
+            };
+            var byteBuffer = new byte[RANDOMIZER.NextShort(8, 256)];
+            RANDOMIZER.NextBytes(byteBuffer);
+            yield return new object[] {
+                RANDOMIZER.NextShort(), 
+                RANDOMIZER.NextShort(), 
+                byteBuffer, 
+                null
+            };
+            yield return new object[] {
+                RANDOMIZER.NextShort(), 
+                RANDOMIZER.NextShort(), 
+                null, 
+                null
+            };
+        }
+        
+        private static IEnumerable<object[]> ValidConstructor4ParamWithDebugTestCaseSource() {
+            yield return new object[] {
+                RANDOMIZER.NextShort(), 
+                RANDOMIZER.NextShort(),
+                Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(new Dictionary<string, string>() { { "viewId", "viewValue" } }, Formatting.None)),
+                null, 
+                true
+            };
+            yield return new object[] {
+                RANDOMIZER.NextShort(), 
+                RANDOMIZER.NextShort(),
+                Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(new Dictionary<string, string>() { { "viewId", "viewValue" } }, Formatting.None)),
+                null, 
+                false
+            };
+        }
+
+        private static IEnumerable<object[]> ValidConstructor5ParamTestCaseSource() {
+            yield return new object[] {
+                RANDOMIZER.NextShort(), 
+                RANDOMIZER.NextShort(),
+                RANDOMIZER.NextShort(),
+                Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(new Dictionary<string, string>() { { "viewId", "viewValue" } }, Formatting.None)),
+                null
+            };
+        }
+
+        private static IEnumerable<object[]> ValidEqualsTestCaseSource() {
+            yield return new object[] {
+                new TestActionType2(), 
+                new TestActionType2()
+            };
+            var evRef = RANDOMIZER.NextShort();
+            var uId = RANDOMIZER.NextShort();
+            var data = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(new Dictionary<string, string>() { { "viewId", "viewValue" } }, Formatting.None));
+            yield return new object[] {
+                new TestActionType2(uId, evRef, data, null),
+                new TestActionType2(uId, evRef, data, null)
+            };
+
+        }
+
+        private static IEnumerable<object[]> InvalidEqualsTestCaseSource() {
+            yield return new object[] {
+                new TestActionType2(), 
+                null
+            };
+            yield return new object[] {
+                new TestActionType2(), 
+                1
+            };
+            var data = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(new Dictionary<string, string>() { { "viewId", "viewValue" } }, Formatting.None));
+            yield return new object[] {
+                new TestActionType2(1, 2, data, null),
+                new TestActionType2(2, 2, data, null)
+            };
+            yield return new object[] {
+                new TestActionType2(1, 1, data, null),
+                new TestActionType2(1, 2, data, null)
+            };
+            //TODO : This fails for GetHashCode but works for Equals 
+            /*yield return new object[] {
+                new TestActionType2(1, 2, data, null),
+                new TestActionType2(1, 2, Array.Empty<byte>(), null)
+            };*/
+        }
+
+        [Test]
+        [Description("Create a new instance of a AbstractActionType2 with no parameters and expect no exceptions to be thrown.")]
+        public void Constructor_NoParam_Valid_DoesNotThrow() {
+            Assert.DoesNotThrow(() => _ = new TestActionType2());
+        }
+
+        [TestCaseSource(nameof(ValidConstructor4ParamTestCaseSource))]
+        [Description("Create a new instance of a AbstractActionType2 with 4 parameters and expect no exceptions to be thrown.")]
+        public void Constructor_4Param_Valid_DoesNotThrow(int id, int eventRef, byte[] dataIn, 
+            ActionTypeCollection.IActionTypeListener listener) {
+            Assert.DoesNotThrow(() => _ = new TestActionType2(id, eventRef, dataIn, listener));
+        }
+        
+        [TestCaseSource(nameof(ValidConstructor4ParamWithDebugTestCaseSource))]
+        [Description("Create a new instance of a AbstractActionType2 with 4 parameters and LogDebug and expect no exceptions to be thrown.")]
+        public void Constructor_4ParamWithDebug_Valid_DoesNotThrow(int id, int eventRef, byte[] dataIn, 
+            ActionTypeCollection.IActionTypeListener listener, bool logDebug) {
+            Assert.DoesNotThrow(() => _ = new TestActionType2(id, eventRef, dataIn, listener, logDebug));
+        }
+        
+        [TestCaseSource(nameof(ValidConstructor5ParamTestCaseSource))]
+        [Description("Create a new instance of a AbstractActionType2 with 5 parameters and expect no exceptions to be thrown.")]
+        public void Constructor_5Param_Valid_DoesNotThrow(int id, int subTypeNumber, int eventRef, byte[] dataIn, 
+            ActionTypeCollection.IActionTypeListener listener) {
+            Assert.DoesNotThrow(() => _ = new TestActionType2(id, subTypeNumber, eventRef, dataIn, listener));
+        }
+        
+        [Test]
+        [Description("Get LogDebug after creating a new AbstractActionType2 and expect the default value to be returned.")]
+        public void LogDebug_Get_ReturnsDefault() {
+            var testActionType2 = new TestActionType2();
+            Assert.AreEqual(false, testActionType2.LogDebug);
+        }
+
+        [TestCaseSource(nameof(ValidBoolTestCaseSource))]
+        [Description("Get LogDebug after creating a new AbstractActionType2 and expect the default value to be returned.")]
+        public void LogDebug_Set_SetsLogDebug(bool logDebug) {
+            var testActionType2 = new TestActionType2 {
+                LogDebug = logDebug
+            };
+            Assert.AreEqual(logDebug, testActionType2.LogDebug);
+        }
+
+        [Test]
+        [Description("Get ActionListener after creating a new AbstractActionType2 and expect the default value to be returned.")]
+        public void ActionListener_Get_ReturnsDefault() {
+            var testActionType2 = new TestActionType2();
+            Assert.AreEqual(null, testActionType2.ActionListener);
+        }
+        
+        [Test]
+        [Description("Get Id after creating a new AbstractActionType2 and expect the default value to be returned.")]
+        public void Id_Get_ReturnsDefault() {
+            var testActionType2 = new TestActionType2();
+            Assert.AreEqual(0, testActionType2.Id);
+        }
+        
+        [Test]
+        [Description("Get EventRef after creating a new AbstractActionType2 and expect the default value to be returned.")]
+        public void EventRef_Get_ReturnsDefault() {
+            var testActionType2 = new TestActionType2();
+            Assert.AreEqual(0, testActionType2.EventRef);
+        }
+        
+        [Test]
+        [Description("Get Data after creating a new AbstractActionType2 and expect the default value to be returned.")]
+        public void Data_Get_ReturnsDefault() {
+            var testActionType2 = new TestActionType2(1, 2, null, null);
+            var defaultData = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(new Dictionary<string, string>() { { testActionType2.InputId, "" } }, Formatting.None));
+            Assert.AreEqual(defaultData, testActionType2.Data);
+        }
+        
+        [Test]
+        [Description("Get Name after creating a new AbstractActionType2 and expect it to not be empty.")]
+        public void Name_Get_IsNotEmpty() {
+            var testActionType2 = new TestActionType2();
+            Assert.IsNotEmpty(testActionType2.Name);
+        }
+        
+        [Test]
+        [Description("Call ToHtml after creating a new AbstractActionType2 and expect the return value to not be empty.")]
+        public void ToHtml_Get_IsNotEmpty() {
+            var testActionType2 = new TestActionType2();
+            Assert.IsNotEmpty(testActionType2.ToHtml());
+        }
+        
+        //TODO ProcessPostData no changes returns true
+        //TODO ProcessPostData with changes and blank ConfigPage returns true
+        //TODO ProcessPostData with changes and non-blank ConfigPage returns true
+        //TODO ProcessPostData with changes not on ConfigPage and non-blank ConfigPage returns true
+        
+        [TestCaseSource(nameof(ValidEqualsTestCaseSource))]
+        [Description("Compare an object with an instance of AbstractActionType2 and expect true to be returned.")]
+        public void Equals_Valid_ReturnsTrue(AbstractActionType2 action, object obj) {
+            Assert.IsTrue(action.Equals(obj));
+        }
+        
+        [TestCaseSource(nameof(InvalidEqualsTestCaseSource))]
+        [Description("Compare an object with an instance of AbstractActionType2 and expect false to be returned.")]
+        public void Equals_Invalid_ReturnsFalse(AbstractActionType2 action, object obj) {
+            Assert.IsFalse(action.Equals(obj));
+        }
+        
+        [TestCaseSource(nameof(ValidEqualsTestCaseSource))]
+        [Description("Compare the hash code of an instance of AbstractActionType2 with another and expect them to be the same.")]
+        public void GetHashCode_Valid_IsSame(AbstractActionType2 action, object obj) {
+            Assert.AreEqual(obj.GetHashCode(), action.GetHashCode());
+        }
+        
+        [TestCaseSource(nameof(InvalidEqualsTestCaseSource))]
+        [Description("Compare the hash code of an instance of AbstractActionType2 with another and expect them to not be the same.")]
+        public void GetHashCode_Invalid_IsNotSame(AbstractActionType2 action, object obj) {
+            Assert.AreNotEqual(obj?.GetHashCode(), action.GetHashCode());
+        }
+
+    }
+
+}

--- a/PluginSdkTests/Events/AbstractTriggerType2Tests.cs
+++ b/PluginSdkTests/Events/AbstractTriggerType2Tests.cs
@@ -1,0 +1,295 @@
+using HomeSeer.Jui.Views;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using NUnit.Framework.Internal;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace HomeSeer.PluginSdk.Events {
+
+    [TestFixture(
+        TestOf = typeof(AbstractTriggerType2),
+        Description = "Tests of the AbstractTriggerType2 class to ensure it behaves as expected under normal conditions.")]
+    public class AbstractTriggerType2Tests {
+
+        private static readonly Randomizer RANDOMIZER = Randomizer.CreateRandomizer();
+
+        private static IEnumerable<bool> ValidBoolTestCaseSource() {
+            yield return false;
+            yield return true;
+        }
+
+        private static IEnumerable<object[]> ValidConstructor3ParamTestCaseSource() {
+            var byteBuffer = new byte[RANDOMIZER.NextShort(8, 256)];
+            RANDOMIZER.NextBytes(byteBuffer);
+            var info = new TrigActInfo {
+                evRef = RANDOMIZER.NextShort(),
+                UID = RANDOMIZER.NextShort(),
+                TANumber = RANDOMIZER.NextShort(),
+                SubTANumber = RANDOMIZER.NextShort(),
+                DataIn = byteBuffer,
+                /*Descriptor = new TrigActSupportInfo {
+                    ComponentType = EEventComponentType.Trigger
+                }*/
+            };
+            yield return new object[] {
+                info,
+                null,
+                RANDOMIZER.NextBool()
+            };
+            info = new TrigActInfo {
+                evRef = RANDOMIZER.NextShort(),
+                UID = RANDOMIZER.NextShort(),
+                TANumber = RANDOMIZER.NextShort(),
+                SubTANumber = RANDOMIZER.NextShort(),
+                DataIn = Encoding.UTF8.GetBytes(
+                    PageFactory.CreateEventActionPage(
+                        RANDOMIZER.GetString(),
+                        RANDOMIZER.GetString()).Page.ToJsonString()),
+                /*Descriptor = new TrigActSupportInfo {
+                    ComponentType = EEventComponentType.Condition
+                }*/
+            };
+            yield return new object[] {
+                info,
+                null,
+                RANDOMIZER.NextBool()
+            };
+            info = new TrigActInfo {
+                evRef = RANDOMIZER.NextShort(),
+                UID = RANDOMIZER.NextShort(),
+                TANumber = RANDOMIZER.NextShort(),
+                SubTANumber = RANDOMIZER.NextShort(),
+                DataIn = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(new Dictionary<string, string>() { { "viewId", "viewValue" } }, Formatting.None)),
+                /*Descriptor = new TrigActSupportInfo {
+                    ComponentType = EEventComponentType.Condition
+                }*/
+            };
+            yield return new object[] {
+                info,
+                null,
+                RANDOMIZER.NextBool()
+            };
+        }
+
+        private static IEnumerable<object[]> ValidConstructor5ParamTestCaseSource() {
+            yield return new object[] {
+                RANDOMIZER.NextShort(),
+                RANDOMIZER.NextShort(),
+                RANDOMIZER.NextShort(),
+                Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(new Dictionary<string, string>() { { "viewId", "viewValue" } }, Formatting.None)),
+                null
+            };
+        }
+
+        private static IEnumerable<object[]> ValidConstructor6ParamTestCaseSource() {
+            yield return new object[] {
+                RANDOMIZER.NextShort(),
+                RANDOMIZER.NextShort(),
+                RANDOMIZER.NextShort(),
+                Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(new Dictionary<string, string>() { { "viewId", "viewValue" } }, Formatting.None)),
+                null,
+                RANDOMIZER.NextBool()
+            };
+        }
+
+        private static IEnumerable<object[]> ValidEqualsTestCaseSource() {
+            var trigger = new TestTriggerType2();
+            yield return new object[] {
+                trigger,
+                trigger
+            };
+            var evRef = RANDOMIZER.NextShort();
+            var uId = RANDOMIZER.NextShort();
+            var data = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(new Dictionary<string, string>() { { "viewId", "viewValue" } }, Formatting.None));
+            yield return new object[] {
+                new TestTriggerType2(uId, evRef, 0, data, null),
+                new TestTriggerType2(uId, evRef, 0, data, null)
+            };
+
+        }
+
+        private static IEnumerable<object[]> InvalidEqualsTestCaseSource() {
+            yield return new object[] {
+                new TestTriggerType2(),
+                null
+            };
+            yield return new object[] {
+                new TestTriggerType2(),
+                1
+            };
+            var data = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(new Dictionary<string, string>() { { "viewId", "viewValue" } }, Formatting.None));
+            yield return new object[] {
+                new TestTriggerType2(1, 2, 0, data, null),
+                new TestTriggerType2(2, 2, 0, data, null)
+            };
+            yield return new object[] {
+                new TestTriggerType2(1, 1, 0, data, null),
+                new TestTriggerType2(1, 2, 0, data, null)
+            };
+            //TODO : Fix this - it works for Equals but does not work for GetHashCode
+            /*yield return new object[] {
+                new TestTriggerType2(1, 2, 0, data, null),
+                new TestTriggerType2(1, 2, 0, Array.Empty<byte>(), null)
+            };*/
+        }
+
+        [Test]
+        [Description("Create a new instance of a AbstractTriggerType2 with no parameters and expect no exceptions to be thrown.")]
+        public void Constructor_NoParam_Valid_DoesNotThrow() {
+            Assert.DoesNotThrow(() => _ = new TestTriggerType2());
+        }
+
+        [TestCaseSource(nameof(ValidConstructor3ParamTestCaseSource))]
+        [Description("Create a new instance of a AbstractTriggerType2 with 3 parameters and expect no exceptions to be thrown.")]
+        public void Constructor_3Param_Valid_DoesNotThrow(TrigActInfo trigInfo,
+            TriggerTypeCollection.ITriggerTypeListener listener, bool logDebug) {
+            Assert.DoesNotThrow(() => _ = new TestTriggerType2(trigInfo, listener, logDebug));
+        }
+
+        [TestCaseSource(nameof(ValidConstructor5ParamTestCaseSource))]
+        [Description("Create a new instance of a AbstractTriggerType2 with 5 parameters and expect no exceptions to be thrown.")]
+        public void Constructor_5Param_Valid_DoesNotThrow(int id, int eventRef, int selectedSubTriggerIndex,
+            byte[] dataIn, TriggerTypeCollection.ITriggerTypeListener listener) {
+            Assert.DoesNotThrow(() => _ = new TestTriggerType2(id, eventRef, selectedSubTriggerIndex, dataIn, listener));
+        }
+
+        [TestCaseSource(nameof(ValidConstructor6ParamTestCaseSource))]
+        [Description("Create a new instance of a AbstractTriggerType2 with 6 parameters and expect no exceptions to be thrown.")]
+        public void Constructor_6Param_Valid_DoesNotThrow(int id, int eventRef, int selectedSubTriggerIndex,
+            byte[] dataIn, TriggerTypeCollection.ITriggerTypeListener listener, bool logDebug) {
+            Assert.DoesNotThrow(() => _ = new TestTriggerType2(id, eventRef, selectedSubTriggerIndex, dataIn, listener, logDebug));
+        }
+
+        [Test]
+        [Description("Get LogDebug after creating a new AbstractTriggerType2 and expect the default value to be returned.")]
+        public void LogDebug_Get_ReturnsDefault() {
+            var testTriggerType2 = new TestTriggerType2();
+            Assert.AreEqual(false, testTriggerType2.LogDebug);
+        }
+
+        [TestCaseSource(nameof(ValidBoolTestCaseSource))]
+        [Description("Get LogDebug after creating a new AbstractTriggerType2 and expect the default value to be returned.")]
+        public void LogDebug_Set_SetsLogDebug(bool logDebug) {
+            var testTriggerType2 = new TestTriggerType2 {
+                LogDebug = logDebug
+            };
+            Assert.AreEqual(logDebug, testTriggerType2.LogDebug);
+        }
+
+        [Test]
+        [Description("Get TriggerListener after creating a new AbstractTriggerType2 and expect the default value to be returned.")]
+        public void TriggerListener_Get_ReturnsDefault() {
+            var testTriggerType2 = new TestTriggerType2();
+            Assert.AreEqual(null, testTriggerType2.TriggerListener);
+        }
+
+        [Test]
+        [Description("Get Id after creating a new AbstractTriggerType2 and expect the default value to be returned.")]
+        public void Id_Get_ReturnsDefault() {
+            var testTriggerType2 = new TestTriggerType2();
+            Assert.AreEqual(0, testTriggerType2.Id);
+        }
+
+        [Test]
+        [Description("Get EventRef after creating a new AbstractTriggerType2 and expect the default value to be returned.")]
+        public void EventRef_Get_ReturnsDefault() {
+            var testTriggerType2 = new TestTriggerType2();
+            Assert.AreEqual(0, testTriggerType2.EventRef);
+        }
+
+        [Test]
+        [Description("Get Data after creating a new AbstractTriggerType2 and expect the default value to be returned.")]
+        public void Data_Get_ReturnsDefault() {
+            var testTriggerType2 = new TestTriggerType2(1, 2, 0, null, null);
+            var defaultData = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(new Dictionary<string, string>() { { testTriggerType2.InputId, "" } }, Formatting.None));
+            Assert.AreEqual(defaultData, testTriggerType2.Data);
+        }
+
+        [Test]
+        [Description("Get Name after creating a new AbstractTriggerType2 and expect it to not be empty.")]
+        public void Name_Get_IsNotEmpty() {
+            var testTriggerType2 = new TestTriggerType2();
+            Assert.IsNotEmpty(testTriggerType2.Name);
+        }
+
+        [Test]
+        [Description("Call ToHtml after creating a new AbstractTriggerType2 and expect the return value to not be empty.")]
+        public void ToHtml_Get_IsNotEmpty() {
+            var testTriggerType2 = new TestTriggerType2();
+            Assert.IsNotEmpty(testTriggerType2.ToHtml());
+        }
+
+        [Test]
+        [Description("Get CanBeCondition after creating a new AbstractTriggerType2 and expect it to not be empty.")]
+        public void CanBeCondition_Get_ReturnsDefault() {
+            var testTriggerType2 = new TestTriggerType2();
+            Assert.AreEqual(false, testTriggerType2.CanBeCondition);
+        }
+
+        [Test]
+        [Description("Get SubTriggerCount after creating a new AbstractTriggerType2 and expect it to not be empty.")]
+        public void SubTriggerCount_Get_ReturnsDefault() {
+            var testTriggerType2 = new TestTriggerType2();
+            Assert.AreEqual(0, testTriggerType2.SubTriggerCount);
+        }
+
+        /*[Test]
+        [Description("Get IsCondition after creating a new AbstractTriggerType2 and expect it to be false.")]
+        public void IsCondition_Get_ReturnsDefault() {
+            var testTriggerType2 = new TestTriggerType2();
+            Assert.AreEqual(false, testTriggerType2.IsCondition);
+        }
+        
+        [Test]
+        [Description("Get IsCondition after creating a new AbstractTriggerType2 as a condition and expect it to be true.")]
+        public void IsCondition_Get_WhenCondition_ReturnsTrue() {
+            var info = new TrigActInfo {
+                evRef = RANDOMIZER.NextShort(),
+                UID = RANDOMIZER.NextShort(),
+                TANumber = RANDOMIZER.NextShort(),
+                SubTANumber = RANDOMIZER.NextShort(),
+                DataIn = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(new Dictionary<string, string>() { { "viewId", "viewValue" } }, Formatting.None)),
+                Descriptor = new TrigActSupportInfo {
+                    ComponentType = EEventComponentType.Condition
+                }
+            };
+            var testTriggerType2 = new TestTriggerType2(info, null);
+            Assert.AreEqual(true, testTriggerType2.IsCondition);
+        }*/
+
+        [Test]
+        [Description("Call GetSubTriggerName after creating a new AbstractTriggerType2 and expect it to throw an exception.")]
+        public void GetSubTriggerName_Get_Default_ThrowsException() {
+            var testTriggerType2 = new TestTriggerType2();
+            Assert.Throws<ArgumentOutOfRangeException>(() => testTriggerType2.GetSubTriggerName(0));
+        }
+
+        [TestCaseSource(nameof(ValidEqualsTestCaseSource))]
+        [Description("Compare an object with an instance of AbstractTriggerType2 and expect true to be returned.")]
+        public void Equals_Valid_ReturnsTrue(AbstractTriggerType2 trigger, object obj) {
+            Assert.IsTrue(trigger.Equals(obj));
+        }
+
+        [TestCaseSource(nameof(InvalidEqualsTestCaseSource))]
+        [Description("Compare an object with an instance of AbstractTriggerType2 and expect false to be returned.")]
+        public void Equals_Invalid_ReturnsFalse(AbstractTriggerType2 trigger, object obj) {
+            Assert.IsFalse(trigger.Equals(obj));
+        }
+
+        [TestCaseSource(nameof(ValidEqualsTestCaseSource))]
+        [Description("Compare the hash code of an instance of AbstractTriggerType2 with another and expect them to be the same.")]
+        public void GetHashCode_Valid_IsSame(AbstractTriggerType2 trigger, object obj) {
+            Assert.AreEqual(obj.GetHashCode(), trigger.GetHashCode());
+        }
+
+        [TestCaseSource(nameof(InvalidEqualsTestCaseSource))]
+        [Description("Compare the hash code of an instance of AbstractTriggerType2 with another and expect them to not be the same.")]
+        public void GetHashCode_Invalid_IsNotSame(AbstractTriggerType2 trigger, object obj) {
+            Assert.AreNotEqual(obj?.GetHashCode(), trigger.GetHashCode());
+        }
+
+    }
+
+}

--- a/PluginSdkTests/Events/TestActionType2.cs
+++ b/PluginSdkTests/Events/TestActionType2.cs
@@ -1,0 +1,59 @@
+using HomeSeer.Jui.Views;
+using System.Collections.Generic;
+
+namespace HomeSeer.PluginSdk.Events {
+
+    /// <summary>
+    /// A test action that can be used to evaluate the functionality of the <see cref="AbstractActionType2"/> class.
+    /// </summary>
+    public sealed class TestActionType2 : AbstractActionType2 {
+
+        public const string ACTION_NAME = "Test Action 2";
+        public string InputId => $"{PageId}-input";
+        public const string INPUT_NAME = "Test Action Input";
+
+        public TestActionType2(int id, int subTypeNumber, int eventRef, byte[] dataIn, ActionTypeCollection.IActionTypeListener listener) : base(id, subTypeNumber, eventRef, dataIn, listener) { }
+        public TestActionType2(int id, int eventRef, byte[] dataIn, ActionTypeCollection.IActionTypeListener listener, bool logDebug = false) : base(id, eventRef, dataIn, listener, logDebug) { }
+        public TestActionType2(int id, int eventRef, byte[] dataIn, ActionTypeCollection.IActionTypeListener listener) : base(id, eventRef, dataIn, listener) { }
+        public TestActionType2() { }
+
+        protected override string GetName() {
+            return ACTION_NAME;
+        }
+
+        protected override void OnInstantiateAction(Dictionary<string, string> viewIdValuePairs) {
+            var confPage = PageFactory.CreateEventActionPage(PageId, GetName());
+            string inputValue = "";
+
+            if (viewIdValuePairs.ContainsKey(InputId)) {
+                inputValue = viewIdValuePairs[InputId];
+            }
+            confPage.WithInput(InputId, INPUT_NAME, inputValue);
+            ConfigPage = confPage.Page;
+        }
+
+        public override bool IsFullyConfigured() {
+            var inputView = ConfigPage.GetViewById<InputView>(InputId);
+            return !string.IsNullOrWhiteSpace(inputView.Value);
+        }
+
+        protected override bool OnConfigItemUpdate(AbstractView configViewChange) {
+            return true;
+        }
+
+        public override string GetPrettyString() {
+            var inputView = ConfigPage.GetViewById<InputView>(InputId);
+            return inputView.Value;
+        }
+
+        public override bool OnRunAction() {
+            return IsFullyConfigured();
+        }
+
+        public override bool ReferencesDeviceOrFeature(int devOrFeatRef) {
+            return false;
+        }
+
+    }
+
+}

--- a/PluginSdkTests/Events/TestTriggerType2.cs
+++ b/PluginSdkTests/Events/TestTriggerType2.cs
@@ -1,0 +1,59 @@
+using HomeSeer.Jui.Views;
+using System.Collections.Generic;
+
+namespace HomeSeer.PluginSdk.Events {
+
+    /// <summary>
+    /// A test trigger that can be used to evaluate the functionality of the <see cref="AbstractTriggerType2"/> class.
+    /// </summary>
+    public class TestTriggerType2 : AbstractTriggerType2 {
+        
+        public const string TRIGGER_NAME = "Test Trigger 2";
+        public string InputId => $"{PageId}-input";
+        public const string INPUT_NAME = "Test Trigger Input";
+
+        public TestTriggerType2(int id, int eventRef, int selectedSubTriggerIndex, byte[] dataIn, TriggerTypeCollection.ITriggerTypeListener listener, bool logDebug = false) : base(id, eventRef, selectedSubTriggerIndex, dataIn, listener, logDebug) { }
+        public TestTriggerType2(int id, int eventRef, int selectedSubTriggerIndex, byte[] dataIn, TriggerTypeCollection.ITriggerTypeListener listener) : base(id, eventRef, selectedSubTriggerIndex, dataIn, listener) { }
+        public TestTriggerType2(TrigActInfo trigInfo, TriggerTypeCollection.ITriggerTypeListener listener, bool logDebug = false) : base(trigInfo, listener, logDebug) { }
+        public TestTriggerType2() { }
+
+        protected override string GetName() {
+            return TRIGGER_NAME;
+        }
+
+        protected override void OnInstantiateTrigger(Dictionary<string, string> viewIdValuePairs) {
+            var confPage = PageFactory.CreateEventTriggerPage(PageId, GetName());
+            string inputValue = "";
+
+            if (viewIdValuePairs.ContainsKey(InputId)) {
+                inputValue = viewIdValuePairs[InputId];
+            }
+            confPage.WithInput(InputId, INPUT_NAME, inputValue);
+            ConfigPage = confPage.Page;
+        }
+
+        public override bool IsFullyConfigured() {
+            var inputView = ConfigPage.GetViewById<InputView>(InputId);
+            return !string.IsNullOrWhiteSpace(inputView.Value);
+        }
+
+        protected override bool OnConfigItemUpdate(AbstractView configViewChange) {
+            return true;
+        }
+
+        public override string GetPrettyString() {
+            var inputView = ConfigPage.GetViewById<InputView>(InputId);
+            return inputView.Value;
+        }
+
+        public override bool IsTriggerTrue(bool isCondition) {
+            return IsFullyConfigured();
+        }
+
+        public override bool ReferencesDeviceOrFeature(int devOrFeatRef) {
+            return false;
+        }
+
+    }
+
+}

--- a/PluginSdkTests/Jui/Tests/SerializationTests.cs
+++ b/PluginSdkTests/Jui/Tests/SerializationTests.cs
@@ -28,7 +28,26 @@ namespace HomeSeer.PluginSdkTests.Jui.Tests {
             return sampleSettingsPage.Page;
 		}
 
-		[Test]
+        private static Page MakeTestEventActionPage() {
+
+            var pageId = new StringBuilder("com-homeseer-pluginsdktests-eventaction");
+            var actionEventPage = PageFactory.CreateEventActionPage(pageId.ToString(), "Event Action");
+
+            List<string> options = new List<string>() { "option1", "option2", "option3" };
+
+            GridView gridView = new GridView("gridview");
+            GridRow gridRow = new GridRow();
+            gridRow.AddItem(new SelectListView("sel1", "Sel1", options));
+            gridRow.AddItem(new SelectListView("sel2", "Sel2", options));
+            gridRow.AddItem(new SelectListView("sel3", "Sel3", options));
+            gridView.AddRow(gridRow);
+
+            actionEventPage.WithView(gridView);
+
+            return actionEventPage.Page;
+        }
+
+        [Test]
 		public void ViewTypeSerializationTest() {
 
 			Console.WriteLine("Starting test");
@@ -43,7 +62,32 @@ namespace HomeSeer.PluginSdkTests.Jui.Tests {
 			Assert.IsTrue(deserializedPage.Equals(testPage));
 		}
 
-		[Test]
+        [Test]
+        [Description("Test that serialization/deserialization of a page preserves the object references when the same object is referenced more than once like for GridView")]
+        public void PreservingObjectReferencesTest() {
+
+            Console.WriteLine("Starting test");
+            var testPage = MakeTestEventActionPage();
+
+            Console.WriteLine("Serializing");
+            var serializedPage = testPage.ToJsonString();
+            Console.WriteLine(serializedPage);
+            Console.WriteLine("Deserializing");
+            var deserializedPage = Page.FromJsonString(serializedPage);
+
+            Assert.IsTrue(deserializedPage.Equals(testPage));
+
+            //Update a view value in both the original page and the deserialized page
+            testPage.UpdateViewValueById("sel1", "2");
+            deserializedPage.UpdateViewValueById("sel1", "2");
+            //Serialize both
+            var serializedOriginalPage = testPage.ToJsonString();
+            var serializedDeserializedPage = deserializedPage.ToJsonString();
+
+            Assert.AreEqual(serializedOriginalPage, serializedDeserializedPage);
+        }
+
+        [Test]
 		public void HtmlTest() {
 			
 			Console.WriteLine("Starting test");

--- a/PluginSdkTests/Jui/Views/SelectListViewTests.cs
+++ b/PluginSdkTests/Jui/Views/SelectListViewTests.cs
@@ -12,9 +12,9 @@ namespace HomeSeer.Jui.Views {
     public class SelectListViewTests : AbstractJuiViewTestFixture {
 
         private static readonly List<string> _defaultOptionKeys = new List<string> {
-            "1", 
-            "2", 
-            "3"
+            "k1", 
+            "k2", 
+            "k3"
         };
         
         private static readonly List<string> _defaultOptions = new List<string> {
@@ -38,7 +38,13 @@ namespace HomeSeer.Jui.Views {
             yield return 1;
             yield return 2;
         }
-        
+
+        private static IEnumerable<string> ValidOptionKeysTestCaseSource() {
+            yield return _defaultOptionKeys[0];
+            yield return _defaultOptionKeys[1];
+            yield return _defaultOptionKeys[2];
+        }
+
         private static IEnumerable<int> InvalidSelectionTestCaseSource() {
             yield return -2;
             yield return 3;
@@ -245,14 +251,23 @@ namespace HomeSeer.Jui.Views {
         }
 
         [TestCaseSource(nameof(ValidSelectionTestCaseSource))]
-        [Description("Call UpdateValue with a valid value and expect Selection to be set.")]
+        [Description("Call UpdateValue  with a valid value and expect Selection to be set.")]
         [Author("JLW")]
         public void UpdateValue_ValidValue_SetsSelection(int selection) {
             SelectListView view = GetDefaultView();
             view.UpdateValue(selection.ToString());
             Assert.AreEqual(selection, view.Selection);
         }
-        
+
+        [TestCaseSource(nameof(ValidOptionKeysTestCaseSource))]
+        [Description("Call UpdateValue for a view with UseOptionKeyAsSelectionValue=true with a valid value and expect Selection to be set.")]
+        public void UpdateValue_ValidValue_UseOptionKeyAsSelectionValue(string optionKey) {
+            SelectListView view = GetDefaultView();
+            view.UseOptionKeyAsSelectionValue = true;
+            view.UpdateValue(optionKey);
+            Assert.AreEqual(optionKey, view.OptionKeys[view.Selection]);
+        }
+
         [TestCaseSource(nameof(InvalidValueTestCaseSource))]
         [Description("Call UpdateValue with an invalid value and expect an exception to be thrown.")]
         [Author("JLW")]
@@ -271,7 +286,16 @@ namespace HomeSeer.Jui.Views {
             view.Selection = selection;
             Assert.AreEqual(selection.ToString(), view.GetStringValue());
         }
-        
+
+        [TestCaseSource(nameof(ValidSelectionTestCaseSource))]
+        [Description("Call GetStringValue for a view with UseOptionKeyAsSelectionValue=true and expect selected option key to be returned.")]
+        public void GetStringValue_UseOptionKeyAsSelectionValue_ReturnsSelectedOptionKey(int selection) {
+            SelectListView view = GetDefaultView();
+            view.UseOptionKeyAsSelectionValue = true;
+            view.Selection = selection;
+            Assert.AreEqual(view.GetSelectedOptionKey(), view.GetStringValue());
+        }
+
         [TestCaseSource(nameof(ValidSelectionOptionTestCaseSource))]
         [Description("Call GetSelectedOption when the selection is valid and expect the correct option to be returned.")]
         [Author("JLW")]

--- a/PluginSdkTests/PluginSdkTests.csproj
+++ b/PluginSdkTests/PluginSdkTests.csproj
@@ -50,11 +50,15 @@
     <Compile Include="Devices\FeatureFactoryTests.cs" />
     <Compile Include="Devices\PlugExtraDataTests.cs" />
     <Compile Include="Devices\ValueRangeTests.cs" />
+    <Compile Include="Events\AbstractActionType2Tests.cs" />
     <Compile Include="Events\AbstractActionTypeTests.cs" />
+    <Compile Include="Events\AbstractTriggerType2Tests.cs" />
     <Compile Include="Events\AbstractTriggerTypeTests.cs" />
     <Compile Include="Events\ActionTypeCollectionTests.cs" />
     <Compile Include="Events\TestActionType.cs" />
+    <Compile Include="Events\TestActionType2.cs" />
     <Compile Include="Events\TestTriggerType.cs" />
+    <Compile Include="Events\TestTriggerType2.cs" />
     <Compile Include="Events\TrigActInfoTests.cs" />
     <Compile Include="Events\TriggerTypeCollectionTests.cs" />
     <Compile Include="Jui\Tests\SerializationTests.cs" />

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.4.2.0")]
-[assembly: AssemblyFileVersion("1.4.2.0")]
+[assembly: AssemblyVersion("1.4.3.0")]
+[assembly: AssemblyFileVersion("1.4.3.0")]

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This SDK is available for your use according to the [GNU Affero General Public L
 <!-- Images & Badges -->
 
 [release-badge]: https://img.shields.io/nuget/v/HomeSeer-PluginSDK
-[hs-version-badge]: https://img.shields.io/badge/Works%20With-HS4.2.14.0%2B-blue
+[hs-version-badge]: https://img.shields.io/badge/Works%20With-HS4.2.17.0%2B-blue
 [maintained-badge]: https://img.shields.io/github/last-commit/HomeSeer/Plugin-SDK
 [hs-logo]: http://homeseer.com/images/HS4/hs4-64.png
 [nuget-downloads]: https://img.shields.io/nuget/dt/HomeSeer-PluginSDK

--- a/samples/samples-cs/HomeSeerSamplePlugin/HomeSeerSamplePlugin.csproj
+++ b/samples/samples-cs/HomeSeerSamplePlugin/HomeSeerSamplePlugin.csproj
@@ -81,6 +81,7 @@
     <Compile Include="Features\SampleGuidedProcessData.cs" />
     <Compile Include="Features\TriggerOptionItem.cs" />
     <Compile Include="HSPI.cs" />
+    <Compile Include="LogDevicePEDActionType.cs" />
     <Compile Include="SampleTriggerType.cs" />
     <Compile Include="SpeakerClient.cs" />
     <Compile Include="WriteLogSampleActionType.cs" />

--- a/samples/samples-cs/HomeSeerSamplePlugin/LogDevicePEDActionType.cs
+++ b/samples/samples-cs/HomeSeerSamplePlugin/LogDevicePEDActionType.cs
@@ -1,0 +1,165 @@
+using System.Collections.Generic;
+using System.Linq;
+using HomeSeer.Jui.Views;
+using HomeSeer.PluginSdk.Events;
+using HomeSeer.PluginSdk.Logging;
+
+namespace HSPI_HomeSeerSamplePlugin {
+
+    /// <summary>
+    /// An event action type that writes the Plugin Extra Data of a device to the HomeSeer log
+    /// </summary>
+    public class LogDevicePEDActionType : AbstractActionType2 {
+
+        /// <summary>
+        /// The name of this action in the list of available actions on the event page
+        /// </summary>
+        private const string ActionName = "Sample Plugin Action - Write Device PED to Log";
+
+        /// <summary>
+        /// The ID of the instructions label view
+        /// </summary>
+        private string InstructionsLabelId => $"{PageId}-instructlabel";
+        /// <summary>
+        /// The value of the instructions label view
+        /// </summary>
+        private const string InstructionsLabelValue = "Write Plugin Extra Data to the Log for device...";
+        /// <summary>
+        /// The ID of the device select list view
+        /// </summary>
+        private string DeviceSelectListId => $"{PageId}-devicesl";
+
+
+        /// <summary>
+        /// The interface bridge to HSPI that enables proper encapsulation of access to the HomeSeer System
+        /// </summary>
+        private ILogDevicePEDActionListener Listener => ActionListener as ILogDevicePEDActionListener;
+
+        /// <inheritdoc />
+        /// <remarks>
+        /// All action types must implement this constructor
+        /// </remarks>
+        public LogDevicePEDActionType(int id, int eventRef, byte[] dataIn, ActionTypeCollection.IActionTypeListener listener, bool logDebug = false) : base(id, eventRef, dataIn, listener, logDebug) { }
+        /// <inheritdoc />
+        /// <remarks>
+        /// All action types must implement this constructor
+        /// </remarks>
+        public LogDevicePEDActionType() { }
+        
+        /// <inheritdoc />
+        /// <remarks>
+        /// Return the name of the action type
+        /// </remarks>
+        protected override string GetName() {
+            return ActionName;
+        }
+
+        /// <inheritdoc />
+        /// <remarks>
+        /// This action type contains a label and a select list
+        /// </remarks>
+        protected override void OnInstantiateAction(Dictionary<string, string> viewIdValuePairs) {
+            var confPage = PageFactory.CreateEventActionPage(PageId, ActionName);
+            var deviceNames = Listener.GetAllDeviceNames().OrderBy(key => key.Value);
+            var options = new List<string>();
+            var optionKeys = new List<string>();
+            int selectedRef = -1;
+            int selectionIndex = -1;
+
+            if(viewIdValuePairs?.ContainsKey(DeviceSelectListId) ?? false) {
+                int.TryParse(viewIdValuePairs[DeviceSelectListId], out selectedRef);
+            }
+
+            int i = 0;
+            foreach (var d in deviceNames) {
+                options.Add(d.Value);
+                optionKeys.Add(d.Key.ToString());
+                if(selectedRef == d.Key) {
+                    selectionIndex = i;
+                }
+                i++;
+            }
+            var deviceSL = new SelectListView(DeviceSelectListId, "Device", options, optionKeys, HomeSeer.Jui.Types.ESelectListType.SearchableDropDown, selectionIndex);
+            //For viewIdValuePairs to contains the selected device ref rather than the selection index, UseOptionKeyAsSelectionValue needs to be true
+            deviceSL.UseOptionKeyAsSelectionValue = true;
+
+            confPage.WithLabel(InstructionsLabelId, null, InstructionsLabelValue);
+            confPage.WithView(deviceSL);
+            
+            ConfigPage = confPage.Page;
+        }
+
+        /// <inheritdoc />
+        /// <remarks>
+        /// This action type is fully configured if a device is selected 
+        /// </remarks>
+        public override bool IsFullyConfigured() {
+            var deviceSL = ConfigPage?.GetViewById(DeviceSelectListId) as SelectListView;
+            if (deviceSL != null && !string.IsNullOrEmpty(deviceSL.GetSelectedOptionKey())) {
+                return true;
+            }
+            return false;
+        }
+
+        /// <inheritdoc />
+        /// <remarks>
+        /// Because all of the available configuration options are select lists, no data validation is needed.
+        ///  This means that we can always return true here so that all changes are saved.
+        /// </remarks>
+        protected override bool OnConfigItemUpdate(AbstractView configViewChange) {
+            return true;
+        }
+
+        /// <inheritdoc />
+        public override string GetPrettyString() {
+            var deviceSL = ConfigPage?.GetViewById(DeviceSelectListId) as SelectListView;
+            var selectedDevice = deviceSL?.GetSelectedOption();
+            return $"Write Plugin Extra Data to the log for {selectedDevice ?? "Unknown Device"}";
+        }
+
+        /// <inheritdoc />
+        /// <remarks>
+        /// This will call to HSPI through the <see cref="ILogDevicePEDActionListener"/> interface to write the PED to the log
+        /// </remarks>
+        public override bool OnRunAction() {
+            var deviceSL = ConfigPage?.GetViewById(DeviceSelectListId) as SelectListView;
+            var selectedDeviceRef = deviceSL?.GetSelectedOptionKey();
+            int deviceRef;
+
+            if (int.TryParse(selectedDeviceRef, out deviceRef)) {
+                Listener.WriteDevicePEDToLog(deviceRef);
+                return true;
+            }
+            return false;
+        }
+
+        /// <inheritdoc />
+        public override bool ReferencesDeviceOrFeature(int devOrFeatRef) {
+            var deviceSL = ConfigPage?.GetViewById(DeviceSelectListId) as SelectListView;
+            var selectedDeviceRef = deviceSL?.GetSelectedOptionKey();
+
+            return selectedDeviceRef == devOrFeatRef.ToString();
+        }
+        
+        /// <summary>
+        /// An interface bridge to HSPI that enables proper encapsulation of access to the HomeSeer System
+        /// </summary>
+        public interface ILogDevicePEDActionListener : ActionTypeCollection.IActionTypeListener {
+
+            /// <summary>
+            /// Write the device Plugin Extra Data to the HomeSeer Log
+            /// </summary>
+            /// <param name="deviceRef">The reference of the device</param>
+            void WriteDevicePEDToLog(int deviceRef);
+
+            /// <summary>
+            /// Get all the device names in the system
+            /// </summary>
+            /// <returns>A collection of device ref - device name pairs</returns>
+            Dictionary<int, string> GetAllDeviceNames();
+
+        }
+
+    }
+
+}


### PR DESCRIPTION
Plugin SDK v1.4.3 is focused on updates to the JUI framework to improve performance and make it more flexible.

- Changes to `GridView`
  - `GridViews` with `SelectListViews` inside of them were not behaving correctly in event actions and triggers. `GridViews` should now behave as expected. (PSDK-291) (#314)
  - `GridRow.HorizontalAlignment` and `GridRow.VerticalAlignment` properties have been added to allow you to change the content alignment within a `GridView` `GridRow`. Use the enums `EHorizontalAlignment` and `EVerticalAlignment`. (PSDK-295)
  - `GridViews` did not align with other views correctly due to some extra padding being added into their HTML. This padding has been removed to better align the view on pages. (PSDK-297)
- Changes to `SelectListView`
  - Allow `SelectListView` to use the option key as the value of the option in HTML (PSDK-299)
  - Include `OptionKeys` in `SelectListView` when posted back from HS (PSDK-101) (#124 #201 #223)
- Change how plugin triggers and actions are saved to events.json (PSDK-298)
  - Previously, the whole page (i.e. collection of JUI views) was serialized and saved to events.json. This was causing some problems for select lists that contain dynamic data (such as a list of devices) because the entire select list is loaded from JSON and no call to the plugin is made to refresh it. Now, we only save a list of key/value pairs to events.json, where the key is the id of the view and the value is the return from `AbstractView.GetStringValue()` (the same thing as the dictionary returned by `Page.ToValueMap()`), and rely on the plugin the provide the translated list of key/value pairs to display to the user. This behavior is automatically handled using `AbstractActionType` and `AbstractTriggerType`, and `AbstractActionType2` and `AbstractTriggerType2` have been added to allow you finer control over this behavior. The sample plugin has been updated to include an example of this; see the "Write Device PED to Log" event action. (PSDK-303)